### PR TITLE
chore: Update defaults to use legacy p2p

### DIFF
--- a/x/genutil/client/cli/init.go
+++ b/x/genutil/client/cli/init.go
@@ -92,7 +92,7 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 			config.P2P.MaxNumInboundPeers = 250
 			config.P2P.MaxNumOutboundPeers = 70
 			config.P2P.MaxConnections = 320
-			config.P2P.BootstrapPeers = "a46bbdb81e66c950e3cdbe5ee748a2d6bdb185dd@161.97.168.77:26656,f0c58d904dec824605ac36114db28f1bf84f6ea3@144.76.112.238:26656" // nolint:lll
+			config.P2P.Seeds = "a46bbdb81e66c950e3cdbe5ee748a2d6bdb185dd@161.97.168.77:26656,f0c58d904dec824605ac36114db28f1bf84f6ea3@144.76.112.238:26656" // nolint:lll
 
 			config.SetRoot(clientCtx.HomeDir)
 

--- a/x/genutil/client/cli/init.go
+++ b/x/genutil/client/cli/init.go
@@ -88,6 +88,12 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 			config.Mempool.KeepInvalidTxsInCache = true
 			config.Mempool.TTLNumBlocks = 15
 
+			config.P2P.UseLegacy = true
+			config.P2P.MaxNumInboundPeers = 250
+			config.P2P.MaxNumOutboundPeers = 70
+			config.P2P.MaxConnections = 320
+			config.P2P.BootstrapPeers = "a46bbdb81e66c950e3cdbe5ee748a2d6bdb185dd@161.97.168.77:26656,f0c58d904dec824605ac36114db28f1bf84f6ea3@144.76.112.238:26656" // nolint:lll
+
 			config.SetRoot(clientCtx.HomeDir)
 
 			chainID, _ := cmd.Flags().GetString(flags.FlagChainID)

--- a/x/genutil/client/cli/init.go
+++ b/x/genutil/client/cli/init.go
@@ -93,6 +93,7 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 			config.P2P.MaxNumOutboundPeers = 70
 			config.P2P.MaxConnections = 320
 			config.P2P.Seeds = "a46bbdb81e66c950e3cdbe5ee748a2d6bdb185dd@161.97.168.77:26656,f0c58d904dec824605ac36114db28f1bf84f6ea3@144.76.112.238:26656" // nolint:lll
+			config.RPC.TimeoutBroadcastTxCommit = time.Second * 40
 
 			config.SetRoot(clientCtx.HomeDir)
 


### PR DESCRIPTION
## Description

This PR changes the default configs to use the legacy p2p stack, along with adding default seed nodes. 

I've tested this manually, but would appreciate if someone else does as well. After replacing the cosmos sdk with this branches latest commit in celestia-app, all we have to do to start a full node is

```shell
celestia-appd init --chain-id mamaki moniker
replace the genesis
celestia-appd start
```

Closes: #XXXX