### PR TITLE
chore: Configure dependabot to only check for Celestia deps.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,62 +1,12 @@
 version: 2
 updates:
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-- package-ecosystem: npm
-  directory: "/docs"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-  reviewers:
-  - fadeev
-- package-ecosystem: gomod
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-  labels:
-  - automerge
-  - dependencies
-- package-ecosystem: gomod
-  directory: "/db"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-  labels:
-  - automerge
-  - dependencies
-- package-ecosystem: gomod
-  directory: "/api"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-  labels:
-  - automerge
-  - dependencies
-- package-ecosystem: gomod
-  directory: "/orm"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-  labels:
-  - automerge
-  - dependencies
-- package-ecosystem: gomod
-  directory: "/container"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-  labels:
-  - automerge
-  - dependencies
-- package-ecosystem: gomod
-  directory: "/cosmovisor"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-  labels:
-  - automerge
-  - dependencies
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    labels:
+      - automerge
+      - dependencies
+    allow:
+      - dependency-name: "*/celestiaorg/*"


### PR DESCRIPTION
Based on https://github.com/celestiaorg/celestia-core/pull/794

We don't actually use dependabot in this repo, since it needs to be kept in line with upstream. Disable dependabot for everything except Celestia Go packages.

One consequence of this change is that any _new_ direct dependencies we introduce that aren't Celestia packages won't be kept up to date by dependabot.