### PR TITLE
chore!: revert "overide default configs in init"

### DIFF
--- a/x/genutil/client/cli/init.go
+++ b/x/genutil/client/cli/init.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/cosmos/go-bip39"
 	"github.com/pkg/errors"
@@ -81,14 +80,6 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 
 			serverCtx := server.GetServerContextFromCmd(cmd)
 			config := serverCtx.Config
-
-			// default mamaki configs TODO: move to the app to be more explicit
-			// in what we are setting as defaults
-			config.Consensus.TimeoutCommit = time.Second * 25
-			config.Consensus.SkipTimeoutCommit = false
-			config.Mempool.KeepInvalidTxsInCache = true
-			config.Mempool.TTLNumBlocks = 15
-
 			config.SetRoot(clientCtx.HomeDir)
 
 			chainID, _ := cmd.Flags().GetString(flags.FlagChainID)


### PR DESCRIPTION
Addresses https://github.com/celestiaorg/celestia-app/issues/669#issuecomment-1315796678 by reverting commit 05f6bde6ecdae6bd1615df985daba6214f17ce84 

This PR should be merged in parallel with https://github.com/celestiaorg/celestia-app/pull/1012