### PR TITLE
chore: Update the default genesis params

### DIFF
--- a/x/auth/types/params.go
+++ b/x/auth/types/params.go
@@ -10,7 +10,7 @@ import (
 
 // Default parameter values
 const (
-	DefaultMaxMemoCharacters      uint64 = 256
+	DefaultMaxMemoCharacters      uint64 = 128
 	DefaultTxSigLimit             uint64 = 7
 	DefaultTxSizeCostPerByte      uint64 = 10
 	DefaultSigVerifyCostED25519   uint64 = 590
@@ -71,8 +71,10 @@ func DefaultParams() Params {
 
 // SigVerifyCostSecp256r1 returns gas fee of secp256r1 signature verification.
 // Set by benchmarking current implementation:
-//     BenchmarkSig/secp256k1     4334   277167 ns/op   4128 B/op   79 allocs/op
-//     BenchmarkSig/secp256r1    10000   108769 ns/op   1672 B/op   33 allocs/op
+//
+//	BenchmarkSig/secp256k1     4334   277167 ns/op   4128 B/op   79 allocs/op
+//	BenchmarkSig/secp256r1    10000   108769 ns/op   1672 B/op   33 allocs/op
+//
 // Based on the results above secp256k1 is 2.7x is slwer. However we propose to discount it
 // because we are we don't compare the cgo implementation of secp256k1, which is faster.
 func (p Params) SigVerifyCostSecp256r1() uint64 {

--- a/x/mint/types/params.go
+++ b/x/mint/types/params.go
@@ -43,9 +43,9 @@ func NewParams(
 func DefaultParams() Params {
 	return Params{
 		MintDenom:           sdk.DefaultBondDenom,
-		InflationRateChange: sdk.ZeroDec(),
-		InflationMax:        sdk.NewDecWithPrec(2, 2),
-		InflationMin:        sdk.NewDecWithPrec(2, 2),
+		InflationRateChange: sdk.NewDecWithPrec(13, 2),
+		InflationMax:        sdk.NewDecWithPrec(20, 2),
+		InflationMin:        sdk.NewDecWithPrec(7, 2),
 		GoalBonded:          sdk.NewDecWithPrec(67, 2),
 		BlocksPerYear:       uint64(60 * 60 * 8766 / 15), // assuming 15 second block times
 	}

--- a/x/mint/types/params.go
+++ b/x/mint/types/params.go
@@ -43,11 +43,11 @@ func NewParams(
 func DefaultParams() Params {
 	return Params{
 		MintDenom:           sdk.DefaultBondDenom,
-		InflationRateChange: sdk.NewDecWithPrec(13, 2),
-		InflationMax:        sdk.NewDecWithPrec(20, 2),
-		InflationMin:        sdk.NewDecWithPrec(7, 2),
+		InflationRateChange: sdk.NewDecWithPrec(1, 2),
+		InflationMax:        sdk.NewDecWithPrec(2, 2),
+		InflationMin:        sdk.NewDecWithPrec(2, 2),
 		GoalBonded:          sdk.NewDecWithPrec(67, 2),
-		BlocksPerYear:       uint64(60 * 60 * 8766 / 5), // assuming 5 second block times
+		BlocksPerYear:       uint64(60 * 60 * 8766 / 15), // assuming 15 second block times
 	}
 }
 

--- a/x/mint/types/params.go
+++ b/x/mint/types/params.go
@@ -43,7 +43,7 @@ func NewParams(
 func DefaultParams() Params {
 	return Params{
 		MintDenom:           sdk.DefaultBondDenom,
-		InflationRateChange: sdk.NewDecWithPrec(1, 2),
+		InflationRateChange: sdk.ZeroDec(),
 		InflationMax:        sdk.NewDecWithPrec(2, 2),
 		InflationMin:        sdk.NewDecWithPrec(2, 2),
 		GoalBonded:          sdk.NewDecWithPrec(67, 2),

--- a/x/slashing/types/params.go
+++ b/x/slashing/types/params.go
@@ -10,7 +10,7 @@ import (
 
 // Default parameter namespace
 const (
-	DefaultSignedBlocksWindow   = int64(100)
+	DefaultSignedBlocksWindow   = int64(5760)
 	DefaultDowntimeJailDuration = 60 * 10 * time.Second
 )
 

--- a/x/slashing/types/params.go
+++ b/x/slashing/types/params.go
@@ -10,7 +10,7 @@ import (
 
 // Default parameter namespace
 const (
-	DefaultSignedBlocksWindow   = int64(5760)
+	DefaultSignedBlocksWindow   = int64(5760) // 4 (blocks per min) * 60 (mins in hour) * 24 (hours in day) = 5760 blocks per day
 	DefaultDowntimeJailDuration = 60 * 10 * time.Second
 )
 

--- a/x/staking/types/params.go
+++ b/x/staking/types/params.go
@@ -33,7 +33,7 @@ const (
 )
 
 // DefaultMinCommissionRate is set to 0%
-var DefaultMinCommissionRate = sdk.ZeroDec()
+var DefaultMinCommissionRate = sdk.NewDecWithPrec(5, 2)
 
 var (
 	KeyUnbondingTime     = []byte("UnbondingTime")

--- a/x/staking/types/params.go
+++ b/x/staking/types/params.go
@@ -32,7 +32,7 @@ const (
 	DefaultHistoricalEntries uint32 = 10000
 )
 
-// DefaultMinCommissionRate is set to 0%
+// DefaultMinCommissionRate is set to .05
 var DefaultMinCommissionRate = sdk.NewDecWithPrec(5, 2)
 
 var (


### PR DESCRIPTION
## Description

During the onsite, we came to a few decisions around selecting a few genesis params. Given how easy they are to change, this PR changes the defaults to the values that we agreed upon. While this increases our diff slightly from upstream, it also will also help us keep params consistent across networks without having to configure them each time.

NOTE: we should not merge this PR, although we are keeping it open to continue the discussion around defualt params

closes https://github.com/celestiaorg/celestia-app/issues/169