### PR TITLE
chore: set the default keyring backend to `test`

### DIFF
--- a/client/config/config.go
+++ b/client/config/config.go
@@ -11,7 +11,7 @@ import (
 // Default constants
 const (
 	chainID        = ""
-	keyringBackend = "os"
+	keyringBackend = "test"
 	output         = "text"
 	node           = "tcp://localhost:26657"
 	broadcastMode  = "sync"

--- a/client/flags/flags.go
+++ b/client/flags/flags.go
@@ -19,7 +19,7 @@ const (
 	GasFlagAuto          = "auto"
 
 	// DefaultKeyringBackend
-	DefaultKeyringBackend = keyring.BackendOS
+	DefaultKeyringBackend = keyring.BackendTest
 
 	// BroadcastBlock defines a tx broadcasting mode where the client waits for
 	// the tx to be committed in a block.


### PR DESCRIPTION
Part of https://github.com/celestiaorg/celestia-app/issues/1201