### PR TITLE
feat!: add baseapp method to create a safe context for `ProcessProposal`

### DIFF
--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -569,9 +569,9 @@ func (app *BaseApp) getState(mode runTxMode) *state {
 }
 
 // NewProcessProposalContext returns a context with a branched version of the
-// DeliverTx state that is safe to use during ProcessProposal.
-func (app *BaseApp) NewProcessProposalContext(h tmproto.Header) sdk.Context {
-	return sdk.NewContext(app.deliverState.ms.CacheMultiStore(), h, false, app.logger)
+// DeliverTx state that is safe to query during ProcessProposal.
+func (app *BaseApp) NewProcessProposalQueryContext() (sdk.Context, error) {
+	return app.createQueryContext(app.cms.LatestVersion(), false)
 }
 
 // retrieve the context for the tx w/ txBytes and other memoized values.

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -568,6 +568,12 @@ func (app *BaseApp) getState(mode runTxMode) *state {
 	return app.checkState
 }
 
+// NewProcessProposalContext returns a context with a branched version of the
+// DeliverTx state that is safe to use during ProcessProposal.
+func (app *BaseApp) NewProcessProposalContext(h tmproto.Header) sdk.Context {
+	return sdk.NewContext(app.deliverState.ms.CacheMultiStore(), h, false, app.logger)
+}
+
 // retrieve the context for the tx w/ txBytes and other memoized values.
 func (app *BaseApp) getContextForTx(mode runTxMode, txBytes []byte) sdk.Context {
 	ctx := app.getState(mode).ctx.


### PR DESCRIPTION
## Description

We need it to safely query the state during `ProcessProposal`, so we wrap an existing unexported method to do so.

part of and blocking https://github.com/celestiaorg/celestia-app/issues/979

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [x] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
- [x] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [x] added a changelog entry to `CHANGELOG.md`
- [x] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [x] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
