### PR TITLE
feat: set proposer-based rewards to 0

### DIFF
--- a/x/distribution/abci_test.go
+++ b/x/distribution/abci_test.go
@@ -104,6 +104,6 @@ func TestVerifyProposerRewardAssignement(t *testing.T) {
 	rewardsValidatorBeforeLazyValidator := app.DistrKeeper.GetValidatorOutstandingRewardsCoins(ctx, validators[lazyValidatorIdx+1].addr)
 	rewardsLazyValidator := app.DistrKeeper.GetValidatorOutstandingRewardsCoins(ctx, validators[lazyValidatorIdx].addr)
 	rewardsValidatorAfterLazyValidator := app.DistrKeeper.GetValidatorOutstandingRewardsCoins(ctx, validators[lazyValidatorIdx+1].addr)
-	require.True(t, rewardsLazyValidator[0].Amount.LT(rewardsValidatorAfterLazyValidator[0].Amount))
+	require.True(t, rewardsLazyValidator[0].Amount.Equal(rewardsValidatorAfterLazyValidator[0].Amount))
 	require.Equal(t, rewardsValidatorBeforeLazyValidator, rewardsValidatorAfterLazyValidator)
 }

--- a/x/distribution/client/testutil/suite.go
+++ b/x/distribution/client/testutil/suite.go
@@ -80,14 +80,14 @@ func (s *IntegrationTestSuite) TestGetCmdQueryParams() {
 		{
 			"json output",
 			[]string{fmt.Sprintf("--%s=json", tmcli.OutputFlag)},
-			`{"community_tax":"0.020000000000000000","base_proposer_reward":"0.010000000000000000","bonus_proposer_reward":"0.040000000000000000","withdraw_addr_enabled":true}`,
+			`{"community_tax":"0.020000000000000000","base_proposer_reward":"0.000000000000000000","bonus_proposer_reward":"0.000000000000000000","withdraw_addr_enabled":true}`,
 		},
 		{
 			"text output",
 			[]string{fmt.Sprintf("--%s=text", tmcli.OutputFlag)},
 			`base_proposer_reward: "0.010000000000000000"
-bonus_proposer_reward: "0.040000000000000000"
-community_tax: "0.020000000000000000"
+bonus_proposer_reward: "0.000000000000000000"
+community_tax: "0.000000000000000000"
 withdraw_addr_enabled: true`,
 		},
 	}

--- a/x/distribution/client/testutil/suite.go
+++ b/x/distribution/client/testutil/suite.go
@@ -85,9 +85,9 @@ func (s *IntegrationTestSuite) TestGetCmdQueryParams() {
 		{
 			"text output",
 			[]string{fmt.Sprintf("--%s=text", tmcli.OutputFlag)},
-			`base_proposer_reward: "0.010000000000000000"
+			`base_proposer_reward: "0.000000000000000000"
 bonus_proposer_reward: "0.000000000000000000"
-community_tax: "0.000000000000000000"
+community_tax: "0.020000000000000000"
 withdraw_addr_enabled: true`,
 		},
 	}

--- a/x/distribution/keeper/allocation_test.go
+++ b/x/distribution/keeper/allocation_test.go
@@ -111,18 +111,18 @@ func TestAllocateTokensToManyValidators(t *testing.T) {
 	app.DistrKeeper.AllocateTokens(ctx, 200, 200, valConsAddr2, votes)
 
 	// 98 outstanding rewards (100 less 2 to community pool)
-	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDecWithPrec(465, 1)}}, app.DistrKeeper.GetValidatorOutstandingRewards(ctx, valAddrs[0]).Rewards)
-	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDecWithPrec(515, 1)}}, app.DistrKeeper.GetValidatorOutstandingRewards(ctx, valAddrs[1]).Rewards)
+	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDecWithPrec(490, 1)}}, app.DistrKeeper.GetValidatorOutstandingRewards(ctx, valAddrs[0]).Rewards)
+	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDecWithPrec(490, 1)}}, app.DistrKeeper.GetValidatorOutstandingRewards(ctx, valAddrs[1]).Rewards)
 	// 2 community pool coins
 	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDec(2)}}, app.DistrKeeper.GetFeePool(ctx).CommunityPool)
 	// 50% commission for first proposer, (0.5 * 93%) * 100 / 2 = 23.25
-	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDecWithPrec(2325, 2)}}, app.DistrKeeper.GetValidatorAccumulatedCommission(ctx, valAddrs[0]).Commission)
+	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDecWithPrec(2450, 2)}}, app.DistrKeeper.GetValidatorAccumulatedCommission(ctx, valAddrs[0]).Commission)
 	// zero commission for second proposer
 	require.True(t, app.DistrKeeper.GetValidatorAccumulatedCommission(ctx, valAddrs[1]).Commission.IsZero())
-	// just staking.proportional for first proposer less commission = (0.5 * 93%) * 100 / 2 = 23.25
-	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDecWithPrec(2325, 2)}}, app.DistrKeeper.GetValidatorCurrentRewards(ctx, valAddrs[0]).Rewards)
-	// proposer reward + staking.proportional for second proposer = (5 % + 0.5 * (93%)) * 100 = 51.5
-	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDecWithPrec(515, 1)}}, app.DistrKeeper.GetValidatorCurrentRewards(ctx, valAddrs[1]).Rewards)
+	// just staking.proportional for first proposer less commission = (0.5 * 98%) * 100 / 2 = 24.50
+	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDecWithPrec(2450, 2)}}, app.DistrKeeper.GetValidatorCurrentRewards(ctx, valAddrs[0]).Rewards)
+	// proposer reward + staking.proportional for second proposer = (0.5 * (98%)) * 100 = 49
+	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDecWithPrec(490, 1)}}, app.DistrKeeper.GetValidatorCurrentRewards(ctx, valAddrs[1]).Rewards)
 }
 
 func TestAllocateTokensTruncation(t *testing.T) {

--- a/x/distribution/types/params.go
+++ b/x/distribution/types/params.go
@@ -26,8 +26,8 @@ func ParamKeyTable() paramtypes.KeyTable {
 func DefaultParams() Params {
 	return Params{
 		CommunityTax:        sdk.NewDecWithPrec(2, 2), // 2%
-		BaseProposerReward:  sdk.NewDecWithPrec(1, 2), // 1%
-		BonusProposerReward: sdk.NewDecWithPrec(4, 2), // 4%
+		BaseProposerReward:  sdk.ZeroDec(),            // deprecated
+		BonusProposerReward: sdk.ZeroDec(),            // deprecated
 		WithdrawAddrEnabled: true,
 	}
 }


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/1589

I briefly considered overriding these params in celestia-app similar to what we do for the gov module [here](https://github.com/celestiaorg/celestia-app/blob/31ab512cdd6f1c2fdc2a8456bbe4abbfdc25b646/app/module.go#L104-L116) but that's a messier diff and the diff introduced in this PR won't be difficult to resolve b/c upstream has deprecated these pararms in https://github.com/cosmos/cosmos-sdk/pull/12876. Tests in this PR were updated based on https://github.com/cosmos/cosmos-sdk/pull/12876.

Note: no Mainnet milestone exists in this repo but this is needed for Mainnet.