### PR TITLE
feat!: make gov proposals with not sdk.Msgs invalid

### DIFF
--- a/x/gov/spec/03_messages.md
+++ b/x/gov/spec/03_messages.md
@@ -16,6 +16,8 @@ must be registered in the app's `MsgServiceRouter`. Each of these messages must
 have one signer, namely the gov module account. And finally, the metadata length
 must not be larger than the `maxMetadataLen` config passed into the gov keeper.
 
+NOTE DIFF FROM UPSTREAM: All proposals must have at least one `sdk.Msg` in the `messages` field.
+
 **State modifications:**
 
 * Generate new `proposalID`

--- a/x/gov/types/v1/msgs.go
+++ b/x/gov/types/v1/msgs.go
@@ -61,9 +61,9 @@ func (m MsgSubmitProposal) ValidateBasic() error {
 		return sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, deposit.String())
 	}
 
-	// Check that either metadata or Msgs length is non nil.
-	if len(m.Messages) == 0 && len(m.Metadata) == 0 {
-		return sdkerrors.Wrap(types.ErrNoProposalMsgs, "either metadata or Msgs length must be non-nil")
+	// Check Msgs length is non nil.
+	if len(m.Messages) == 0 {
+		return sdkerrors.Wrap(types.ErrNoProposalMsgs, "Msgs length must be non-nil")
 	}
 
 	msgs, err := m.GetMsgs()

--- a/x/gov/types/v1/msgs_test.go
+++ b/x/gov/types/v1/msgs_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+	v1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	"github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 )
 
@@ -151,7 +151,7 @@ func TestMsgSubmitProposal_ValidateBasic(t *testing.T) {
 		{"invalid addr", "", coinsPos, []sdk.Msg{msg1}, metadata, true},
 		{"empty msgs and metadata", addrs[0].String(), coinsPos, nil, "", true},
 		{"invalid msg", addrs[0].String(), coinsPos, []sdk.Msg{msg1, msg2}, metadata, true},
-		{"valid with no Msg", addrs[0].String(), coinsPos, nil, metadata, false},
+		{"invalid with no Msg", addrs[0].String(), coinsPos, nil, metadata, true},
 		{"valid with no metadata", addrs[0].String(), coinsPos, []sdk.Msg{msg1}, "", false},
 		{"valid with everything", addrs[0].String(), coinsPos, []sdk.Msg{msg1}, metadata, false},
 	}


### PR DESCRIPTION
## Description

this PR modifies the validate basic method of the MsgSubmitProposal type to invalidate proposals with no sdk.Msgs

closes https://github.com/celestiaorg/celestia-app/issues/1680