### PR TITLE
feat: allow for the default consensus params to be set by the application

### DIFF
--- a/server/util.go
+++ b/server/util.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/store"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/version"
+	cmtproto "github.com/tendermint/tendermint/proto/tendermint/types"
 )
 
 // DONTCOVER
@@ -43,9 +44,10 @@ const ServerContextKey = sdk.ContextKey("server.context")
 
 // server context
 type Context struct {
-	Viper  *viper.Viper
-	Config *tmcfg.Config
-	Logger tmlog.Logger
+	Viper                  *viper.Viper
+	Config                 *tmcfg.Config
+	Logger                 tmlog.Logger
+	DefaultConsensusParams *cmtproto.ConsensusParams
 }
 
 // ErrorCode contains the exit code for server exit.
@@ -66,7 +68,7 @@ func NewDefaultContext() *Context {
 }
 
 func NewContext(v *viper.Viper, config *tmcfg.Config, logger tmlog.Logger) *Context {
-	return &Context{v, config, logger}
+	return &Context{v, config, logger, nil}
 }
 
 func bindFlags(basename string, cmd *cobra.Command, v *viper.Viper) (err error) {

--- a/x/genutil/client/cli/init.go
+++ b/x/genutil/client/cli/init.go
@@ -163,6 +163,10 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 			genDoc.Validators = nil
 			genDoc.AppState = appState
 
+			if serverCtx.DefaultConsensusParams != nil {
+				genDoc.ConsensusParams = serverCtx.DefaultConsensusParams
+			}
+
 			if err = genutil.ExportGenesisFile(genDoc, genFile); err != nil {
 				return errors.Wrap(err, "Failed to export genesis file")
 			}

--- a/x/genutil/client/cli/init_test.go
+++ b/x/genutil/client/cli/init_test.go
@@ -292,7 +292,7 @@ func TestInitWithConsensusParams(t *testing.T) {
 
 	serverCtx := server.NewContext(viper.New(), cfg, logger)
 
-	// set new defult consensus params
+	// set new default consensus params
 	cps := coretypes.DefaultConsensusParams()
 	cps.Block.MaxBytes = 100000000
 	cps.Block.MaxGas = 420420420

--- a/x/genutil/client/cli/init_test.go
+++ b/x/genutil/client/cli/init_test.go
@@ -14,6 +14,7 @@ import (
 	abci_server "github.com/tendermint/tendermint/abci/server"
 	"github.com/tendermint/tendermint/libs/cli"
 	"github.com/tendermint/tendermint/libs/log"
+	coretypes "github.com/tendermint/tendermint/types"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -281,6 +282,43 @@ func TestInitConfig(t *testing.T) {
 	out := <-outC
 
 	require.Contains(t, out, "\"chain_id\": \"foo\"")
+}
+
+func TestInitWithConsensusParams(t *testing.T) {
+	home := t.TempDir()
+	logger := log.NewNopLogger()
+	cfg, err := genutiltest.CreateDefaultTendermintConfig(home)
+	require.NoError(t, err)
+
+	serverCtx := server.NewContext(viper.New(), cfg, logger)
+
+	// set new defult consensus params
+	cps := coretypes.DefaultConsensusParams()
+	cps.Block.MaxBytes = 100000000
+	cps.Block.MaxGas = 420420420
+	serverCtx.DefaultConsensusParams = cps
+
+	interfaceRegistry := types.NewInterfaceRegistry()
+	marshaler := codec.NewProtoCodec(interfaceRegistry)
+	clientCtx := client.Context{}.
+		WithCodec(marshaler).
+		WithLegacyAmino(makeCodec()).
+		WithHomeDir(home)
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, client.ClientContextKey, &clientCtx)
+	ctx = context.WithValue(ctx, server.ServerContextKey, serverCtx)
+
+	cmd := genutilcli.InitCmd(testMbm, home)
+	cmd.SetArgs([]string{"testnode"})
+
+	err = cmd.ExecuteContext(ctx)
+	require.NoError(t, err)
+
+	genDoc, err := coretypes.GenesisDocFromFile(cfg.GenesisFile())
+	require.NoError(t, err)
+
+	require.Equal(t, genDoc.ConsensusParams, cps)
 }
 
 // custom tx codec


### PR DESCRIPTION
## Description

This PR adds the consensus params to the server context, so that the init cli command can add it to the genesis document. This allows for the consensus parameters to be set by the application.
