### PR TITLE
fix: query tx events with `>=` and `<=` operators

### DIFF
--- a/x/auth/tx/service.go
+++ b/x/auth/tx/service.go
@@ -45,7 +45,8 @@ var (
 	_ txtypes.ServiceServer = txServer{}
 
 	// EventRegex checks that an event string is formatted with {alphabetic}.{alphabetic}={value}
-	EventRegex = regexp.MustCompile(`^[a-zA-Z_]+\.[a-zA-Z_]+=\S+$`)
+	// Note: in addition to equality, the `>=` and `<=` operators are also valid.
+	EventRegex = regexp.MustCompile(`^[a-zA-Z_]+\.[a-zA-Z_]+[<>]?=\S+$`)
 )
 
 const (

--- a/x/auth/tx/service_test.go
+++ b/x/auth/tx/service_test.go
@@ -184,6 +184,16 @@ func TestEventRegex(t *testing.T) {
 			event: "tx.signature='foobar/baz123=='",
 			match: true,
 		},
+		{
+			name:  "valid: with >= operator",
+			event: "tx.height>=10'",
+			match: true,
+		},
+		{
+			name:  "valid: with <= operator",
+			event: "tx.height<=10'",
+			match: true,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Part of https://github.com/celestiaorg/celestia-app/issues/2098

## Testing

### Before
```
$ curl http://localhost:1317/cosmos/tx/v1beta1/txs?events=tx.height%3C=10
{
"code": 3,
"message": "invalid event; event tx.height\u003c=10 should be of the format: {eventType}.{eventAttribute}={value}",
"details": [
]
}%
```

### After

```shell
$ curl http://localhost:1317/cosmos/tx/v1beta1/txs?events=tx.height%3C=10
{
  "txs": [
  ],
  "tx_responses": [
  ],
  "pagination": null,
  "total": "0"
}%
```

## FLUPs

1. Cut a release of this repo and bump in celestia-app
1. Get a fix for this issue merged to upstream cosmos-sdk https://github.com/cosmos/cosmos-sdk/pull/16994 and pull it here