### PR TITLE
feat!: add app version to param store

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -60,6 +60,9 @@ func (app *BaseApp) InitChain(req abci.RequestInitChain) (res abci.ResponseInitC
 	// to state.
 	if req.ConsensusParams != nil {
 		app.StoreConsensusParams(app.deliverState.ctx, req.ConsensusParams)
+		if req.ConsensusParams.Version != nil {
+			app.appVersion = req.ConsensusParams.Version.AppVersion
+		}
 	}
 
 	if app.initChainer == nil {

--- a/baseapp/options.go
+++ b/baseapp/options.go
@@ -113,8 +113,12 @@ func (app *BaseApp) SetVersion(v string) {
 
 // SetAppVersion sets the application's protocol version
 func (app *BaseApp) SetAppVersion(ctx sdk.Context, v uint64) {
-	vp := &tmproto.VersionParams{AppVersion: v}
-	app.paramStore.Set(ctx, ParamStoreKeyVersionParams, vp)
+	// TODO: could make this less hacky in the future since the SDK
+	// shouldn't have to know about the app versioning scheme
+	if ctx.BlockHeader().Version.App >= 2 {
+		vp := &tmproto.VersionParams{AppVersion: v}
+		app.paramStore.Set(ctx, ParamStoreKeyVersionParams, vp)
+	}
 	app.appVersion = v
 }
 

--- a/baseapp/options.go
+++ b/baseapp/options.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	dbm "github.com/tendermint/tm-db"
 
 	"github.com/cosmos/cosmos-sdk/codec/types"
@@ -110,8 +111,10 @@ func (app *BaseApp) SetVersion(v string) {
 	app.version = v
 }
 
-// SetProtocolVersion sets the application's protocol version
-func (app *BaseApp) SetProtocolVersion(v uint64) {
+// SetAppVersion sets the application's protocol version
+func (app *BaseApp) SetAppVersion(ctx sdk.Context, v uint64) {
+	vp := &tmproto.VersionParams{AppVersion: v}
+	app.paramStore.Set(ctx, ParamStoreKeyVersionParams, vp)
 	app.appVersion = v
 }
 

--- a/baseapp/params.go
+++ b/baseapp/params.go
@@ -18,6 +18,7 @@ var (
 	ParamStoreKeyBlockParams     = []byte("BlockParams")
 	ParamStoreKeyEvidenceParams  = []byte("EvidenceParams")
 	ParamStoreKeyValidatorParams = []byte("ValidatorParams")
+	ParamStoreKeyVersionParams   = []byte("VersionParams")
 )
 
 // ParamStore defines the interface the parameter store used by the BaseApp must
@@ -80,6 +81,21 @@ func ValidateValidatorParams(i interface{}) error {
 
 	if len(v.PubKeyTypes) == 0 {
 		return errors.New("validator allowed pubkey types must not be empty")
+	}
+
+	return nil
+}
+
+// ValidateVersionParams defines a stateless validation on VersionParams. This
+// function is called whenever the parameters are updated or stored.
+func ValidateVersionParams(i interface{}) error {
+	v, ok := i.(tmproto.VersionParams)
+	if !ok {
+		return fmt.Errorf("invalid parameter type: %T", i)
+	}
+
+	if v.AppVersion == 0 {
+		return errors.New("application version must not be zero")
 	}
 
 	return nil

--- a/x/params/types/consensus_params.go
+++ b/x/params/types/consensus_params.go
@@ -23,5 +23,8 @@ func ConsensusParamsKeyTable() KeyTable {
 		NewParamSetPair(
 			baseapp.ParamStoreKeyValidatorParams, tmproto.ValidatorParams{}, baseapp.ValidateValidatorParams,
 		),
+		NewParamSetPair(
+			baseapp.ParamStoreKeyVersionParams, tmproto.VersionParams{}, baseapp.ValidateVersionParams,
+		),
 	)
 }

--- a/x/upgrade/exported/exported.go
+++ b/x/upgrade/exported/exported.go
@@ -1,7 +1,9 @@
 package exported
 
+import sdk "github.com/cosmos/cosmos-sdk/types"
+
 // ProtocolVersionSetter defines the interface fulfilled by BaseApp
 // which allows setting it's appVersion field.
 type ProtocolVersionSetter interface {
-	SetProtocolVersion(uint64)
+	SetAppVersion(sdk.Context, uint64)
 }

--- a/x/upgrade/keeper/keeper.go
+++ b/x/upgrade/keeper/keeper.go
@@ -346,7 +346,7 @@ func (k Keeper) ApplyUpgrade(ctx sdk.Context, plan types.Plan) {
 	k.setProtocolVersion(ctx, nextProtocolVersion)
 	if k.versionSetter != nil {
 		// set protocol version on BaseApp
-		k.versionSetter.SetProtocolVersion(nextProtocolVersion)
+		k.versionSetter.SetAppVersion(ctx, nextProtocolVersion)
 	}
 
 	// Must clear IBC state after upgrade is applied as it is stored separately from the upgrade plan.


### PR DESCRIPTION
## Description

This PR adds app version to the `ParamStore` meaning that app version is no longer just in memory but is also persisted. We need this for example when a node restarts as Tendermint will call `Info` and it must remember the correct app version. It's also important for ensuring that state sync works beyond v1

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
