### PR TITLE
feat: only update the app version when at 0

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -125,8 +125,8 @@ func (app *BaseApp) SetOption(req abci.RequestSetOption) (res abci.ResponseSetOp
 // Info implements the ABCI interface.
 func (app *BaseApp) Info(req abci.RequestInfo) abci.ResponseInfo {
 	lastCommitID := app.cms.LastCommitID()
-	// load the app version for a non zero height
-	if lastCommitID.Version > 0 {
+	// load the app version for a non zero height and zero app hash
+	if lastCommitID.Version > 0 && app.appVersion == 0 {
 		ctx, err := app.createQueryContext(lastCommitID.Version, false)
 		if err != nil {
 			panic(err)

--- a/baseapp/options.go
+++ b/baseapp/options.go
@@ -112,14 +112,14 @@ func (app *BaseApp) SetVersion(v string) {
 }
 
 // SetAppVersion sets the application's protocol version
-func (app *BaseApp) SetAppVersion(ctx sdk.Context, v uint64) {
+func (app *BaseApp) SetAppVersion(ctx sdk.Context, version uint64) {
 	// TODO: could make this less hacky in the future since the SDK
 	// shouldn't have to know about the app versioning scheme
-	if ctx.BlockHeader().Version.App >= 2 {
-		vp := &tmproto.VersionParams{AppVersion: v}
+	if version >= 2 {
+		vp := &tmproto.VersionParams{AppVersion: version}
 		app.paramStore.Set(ctx, ParamStoreKeyVersionParams, vp)
 	}
-	app.appVersion = v
+	app.appVersion = version
 }
 
 func (app *BaseApp) SetDB(db dbm.DB) {


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

This is a minor change after testing out the upgrade process using celestia-app.

It fixes the bug of using the passed version instead of ctx.BlockHeader().Version.App

It also only loads the `appVersion` parameter from disk once upon startup (which is when the `Info` method is called)

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
