### PR TITLE
fix: add app version in the context in InitChain

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	abci "github.com/tendermint/tendermint/abci/types"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+	tmversion "github.com/tendermint/tendermint/proto/tendermint/version"
 	"google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
 
@@ -37,13 +38,17 @@ const (
 func (app *BaseApp) InitChain(req abci.RequestInitChain) (res abci.ResponseInitChain) {
 	// On a new chain, we consider the init chain block height as 0, even though
 	// req.InitialHeight is 1 by default.
-	initHeader := tmproto.Header{ChainID: req.ChainId, Time: req.Time}
+	initHeader := tmproto.Header{
+		ChainID: req.ChainId,
+		Time:    req.Time,
+		Version: tmversion.Consensus{App: req.ConsensusParams.Version.AppVersion},
+	}
 
 	// If req.InitialHeight is > 1, then we set the initial version in the
 	// stores.
 	if req.InitialHeight > 1 {
 		app.initialHeight = req.InitialHeight
-		initHeader = tmproto.Header{ChainID: req.ChainId, Height: req.InitialHeight, Time: req.Time}
+		initHeader.Height = req.InitialHeight
 		err := app.cms.SetInitialVersion(req.InitialHeight)
 		if err != nil {
 			panic(err)
@@ -58,12 +63,8 @@ func (app *BaseApp) InitChain(req abci.RequestInitChain) (res abci.ResponseInitC
 	// Store the consensus params in the BaseApp's paramstore. Note, this must be
 	// done after the deliver state and context have been set as it's persisted
 	// to state.
-	if req.ConsensusParams != nil {
-		app.StoreConsensusParams(app.deliverState.ctx, req.ConsensusParams)
-		if req.ConsensusParams.Version != nil {
-			app.appVersion = req.ConsensusParams.Version.AppVersion
-		}
-	}
+	app.StoreConsensusParams(app.deliverState.ctx, req.ConsensusParams)
+	app.appVersion = req.ConsensusParams.Version.AppVersion
 
 	if app.initChainer == nil {
 		return res
@@ -131,8 +132,8 @@ func (app *BaseApp) Info(req abci.RequestInfo) abci.ResponseInfo {
 		if err != nil {
 			panic(err)
 		}
-		// get and set the app version
-		_ = app.AppVersion(ctx)
+		// initialise the app version by checking if it is already in state
+		app.InitAppVersion(ctx)
 	}
 	return abci.ResponseInfo{
 		Data:             app.name,

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -38,10 +38,9 @@ const (
 func (app *BaseApp) InitChain(req abci.RequestInitChain) (res abci.ResponseInitChain) {
 	// On a new chain, we consider the init chain block height as 0, even though
 	// req.InitialHeight is 1 by default.
-	initHeader := tmproto.Header{
-		ChainID: req.ChainId,
-		Time:    req.Time,
-		Version: tmversion.Consensus{App: req.ConsensusParams.Version.AppVersion},
+	initHeader := tmproto.Header{ChainID: req.ChainId, Time: req.Time}
+	if req.ConsensusParams != nil && req.ConsensusParams.Version != nil {
+		initHeader.Version = tmversion.Consensus{App: req.ConsensusParams.Version.AppVersion}
 	}
 
 	// If req.InitialHeight is > 1, then we set the initial version in the
@@ -63,8 +62,12 @@ func (app *BaseApp) InitChain(req abci.RequestInitChain) (res abci.ResponseInitC
 	// Store the consensus params in the BaseApp's paramstore. Note, this must be
 	// done after the deliver state and context have been set as it's persisted
 	// to state.
-	app.StoreConsensusParams(app.deliverState.ctx, req.ConsensusParams)
-	app.appVersion = req.ConsensusParams.Version.AppVersion
+	if req.ConsensusParams != nil {
+		app.StoreConsensusParams(app.deliverState.ctx, req.ConsensusParams)
+		if req.ConsensusParams.Version != nil {
+			app.appVersion = req.ConsensusParams.Version.AppVersion
+		}
+	}
 
 	if app.initChainer == nil {
 		return res

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -202,15 +202,17 @@ func (app *BaseApp) Name() string {
 	return app.name
 }
 
-// AppVersion returns the application's protocol version.
-func (app *BaseApp) AppVersion(ctx sdk.Context) uint64 {
+func (app *BaseApp) InitAppVersion(ctx sdk.Context) {
 	if app.appVersion == 0 && app.paramStore.Has(ctx, ParamStoreKeyVersionParams) {
 		var vp tmproto.VersionParams
-
 		app.paramStore.Get(ctx, ParamStoreKeyVersionParams, &vp)
 		// set the app version
 		app.appVersion = vp.AppVersion
 	}
+}
+
+// AppVersion returns the application's protocol version.
+func (app *BaseApp) AppVersion() uint64 {
 	return app.appVersion
 }
 

--- a/baseapp/options.go
+++ b/baseapp/options.go
@@ -113,9 +113,7 @@ func (app *BaseApp) SetVersion(v string) {
 
 // SetAppVersion sets the application's protocol version
 func (app *BaseApp) SetAppVersion(ctx sdk.Context, version uint64) {
-	// TODO: could make this less hacky in the future since the SDK
-	// shouldn't have to know about the app versioning scheme
-	if version >= 2 {
+	if app.paramStore.Has(ctx, ParamStoreKeyVersionParams) {
 		vp := &tmproto.VersionParams{AppVersion: version}
 		app.paramStore.Set(ctx, ParamStoreKeyVersionParams, vp)
 	}

--- a/types/module/module_test.go
+++ b/types/module/module_test.go
@@ -280,5 +280,6 @@ func TestManager_EndBlock(t *testing.T) {
 	// test panic
 	mockAppModule1.EXPECT().EndBlock(gomock.Any(), gomock.Eq(req)).Times(1).Return([]abci.ValidatorUpdate{{}})
 	mockAppModule2.EXPECT().EndBlock(gomock.Any(), gomock.Eq(req)).Times(1).Return([]abci.ValidatorUpdate{{}})
+	mm.EndBlock(sdk.Context{}, req)
 	require.Panics(t, func() { mm.EndBlock(sdk.Context{}, req) })
 }

--- a/types/module/module_test.go
+++ b/types/module/module_test.go
@@ -280,6 +280,5 @@ func TestManager_EndBlock(t *testing.T) {
 	// test panic
 	mockAppModule1.EXPECT().EndBlock(gomock.Any(), gomock.Eq(req)).Times(1).Return([]abci.ValidatorUpdate{{}})
 	mockAppModule2.EXPECT().EndBlock(gomock.Any(), gomock.Eq(req)).Times(1).Return([]abci.ValidatorUpdate{{}})
-	mm.EndBlock(sdk.Context{}, req)
 	require.Panics(t, func() { mm.EndBlock(sdk.Context{}, req) })
 }

--- a/x/upgrade/keeper/keeper_test.go
+++ b/x/upgrade/keeper/keeper_test.go
@@ -203,7 +203,7 @@ func (s *KeeperTestSuite) TestSetUpgradedClient() {
 // Test that the protocol version successfully increments after an
 // upgrade and is successfully set on BaseApp's appVersion.
 func (s *KeeperTestSuite) TestIncrementProtocolVersion() {
-	oldProtocolVersion := s.app.BaseApp.AppVersion(s.ctx)
+	oldProtocolVersion := s.app.BaseApp.AppVersion()
 	s.app.UpgradeKeeper.SetUpgradeHandler("dummy", func(_ sdk.Context, _ types.Plan, vm module.VersionMap) (module.VersionMap, error) { return vm, nil })
 	dummyPlan := types.Plan{
 		Name:   "dummy",
@@ -211,7 +211,7 @@ func (s *KeeperTestSuite) TestIncrementProtocolVersion() {
 		Height: 100,
 	}
 	s.app.UpgradeKeeper.ApplyUpgrade(s.ctx, dummyPlan)
-	upgradedProtocolVersion := s.app.BaseApp.AppVersion(s.ctx)
+	upgradedProtocolVersion := s.app.BaseApp.AppVersion()
 
 	s.Require().Equal(oldProtocolVersion+1, upgradedProtocolVersion)
 }


### PR DESCRIPTION
## Description

Currently, the app version is not passed into the context for `InitGenesis` which causes transactions that rely on the app version (or specifically the antehandler) to fail and panic.

This PR adds the app verison. It also simplifies the API around initialising, setting and getting the AppVersion

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
