### PR TITLE
fix: allow the application to set the initial app version in the consensus params

### DIFF
--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -493,6 +493,8 @@ func (app *BaseApp) GetConsensusParams(ctx sdk.Context) *abci.ConsensusParams {
 
 		app.paramStore.Get(ctx, ParamStoreKeyVersionParams, &vp)
 		cp.Version = &vp
+	} else if app.appVersion != 0 {
+		cp.Version = &tmproto.VersionParams{AppVersion: app.appVersion}
 	}
 
 	return cp

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -518,9 +518,16 @@ func (app *BaseApp) StoreConsensusParams(ctx sdk.Context, cp *abci.ConsensusPara
 	app.paramStore.Set(ctx, ParamStoreKeyBlockParams, cp.Block)
 	app.paramStore.Set(ctx, ParamStoreKeyEvidenceParams, cp.Evidence)
 	app.paramStore.Set(ctx, ParamStoreKeyValidatorParams, cp.Validator)
-	// NOTE: we only persist the app version from v2 onwards
-	if cp.Version != nil && cp.Version.AppVersion >= 2 {
+	if app.paramStore.Has(ctx, ParamStoreKeyVersionParams) {
 		app.paramStore.Set(ctx, ParamStoreKeyVersionParams, cp.Version)
+	}
+}
+
+// SetInitialAppVersionInConsensusParams sets the initial app version
+// in the consensus params if it has not yet been set.
+func (app *BaseApp) SetInitialAppVersionInConsensusParams(ctx sdk.Context, version uint64) {
+	if !app.paramStore.Has(ctx, ParamStoreKeyVersionParams) {
+		app.paramStore.Set(ctx, ParamStoreKeyVersionParams, &tmproto.VersionParams{AppVersion: version})
 	}
 }
 


### PR DESCRIPTION
## Description

`BaseApp` won't set the app version from  unless it's already been intialised preventing us from performing the first upgrade from v1 to v2

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
