### PR TITLE
feat!: add migrator to the commit abci call

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -130,7 +130,7 @@ func (app *BaseApp) SetOption(req abci.RequestSetOption) (res abci.ResponseSetOp
 func (app *BaseApp) Info(req abci.RequestInfo) abci.ResponseInfo {
 	lastCommitID := app.cms.LastCommitID()
 	// load the app version for a non zero height and zero app hash
-	if lastCommitID.Version > 0 {
+	if lastCommitID.Version > 0 && app.appVersion == 0 {
 		ctx, err := app.createQueryContext(lastCommitID.Version, false)
 		if err != nil {
 			panic(err)

--- a/baseapp/options.go
+++ b/baseapp/options.go
@@ -3,6 +3,7 @@ package baseapp
 import (
 	"fmt"
 	"io"
+	"sort"
 
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	dbm "github.com/tendermint/tm-db"
@@ -293,6 +294,9 @@ func (sm StoreMigrations) ToStoreUpgrades() *storetypes.StoreUpgrades {
 		deleted[i] = name
 		i++
 	}
+	// sort them to ensure deterministic order
+	sort.Strings(added)
+	sort.Strings(deleted)
 	return &storetypes.StoreUpgrades{
 		Added:   added,
 		Deleted: deleted,


### PR DESCRIPTION
This PR addresses the app hash bug identified in this issue: https://github.com/celestiaorg/celestia-app/issues/3167

It introduces a `migrator` struct to `BaseApp` which allows the application to handle adding and removing stores as well as performing module migrations to any store.

This needs to be done in `Commit` as we need to first write the changes on the current deliver tx branch of state, add and remove the stores from the `MultiCommitStore` and then create a new branch of state to perform the migrations on. Only once they are completed and written can we calculate the new app hash