### PR TITLE
fix: allow application to set and query app version

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -128,16 +128,8 @@ func (app *BaseApp) SetOption(req abci.RequestSetOption) (res abci.ResponseSetOp
 
 // Info implements the ABCI interface.
 func (app *BaseApp) Info(req abci.RequestInfo) abci.ResponseInfo {
+	// get the latest height and app hash
 	lastCommitID := app.cms.LastCommitID()
-	// load the app version for a non zero height and zero app hash
-	if lastCommitID.Version > 0 && app.appVersion == 0 {
-		ctx, err := app.createQueryContext(lastCommitID.Version, false)
-		if err != nil {
-			panic(err)
-		}
-		// initialise the app version by checking if it is already in state
-		app.InitAppVersion(ctx)
-	}
 	return abci.ResponseInfo{
 		Data:             app.name,
 		Version:          app.version,
@@ -621,7 +613,7 @@ func (app *BaseApp) ApplySnapshotChunk(req abci.RequestApplySnapshotChunk) abci.
 }
 
 func (app *BaseApp) handleQueryGRPC(handler GRPCQueryHandler, req abci.RequestQuery) abci.ResponseQuery {
-	ctx, err := app.createQueryContext(req.Height, req.Prove)
+	ctx, err := app.CreateQueryContext(req.Height, req.Prove)
 	if err != nil {
 		return sdkerrors.QueryResult(err, app.trace)
 	}
@@ -669,7 +661,7 @@ func checkNegativeHeight(height int64) error {
 
 // createQueryContext creates a new sdk.Context for a query, taking as args
 // the block height and whether the query needs a proof or not.
-func (app *BaseApp) createQueryContext(height int64, prove bool) (sdk.Context, error) {
+func (app *BaseApp) CreateQueryContext(height int64, prove bool) (sdk.Context, error) {
 	if err := checkNegativeHeight(height); err != nil {
 		return sdk.Context{}, err
 	}
@@ -709,6 +701,10 @@ func (app *BaseApp) createQueryContext(height int64, prove bool) (sdk.Context, e
 				sdkerrors.ErrInvalidRequest,
 				"failed to load state at height %d; %s (latest height: %d)", height, err, lastBlockHeight,
 			)
+	}
+
+	if app.checkState == nil {
+		app.setCheckState(tmproto.Header{Height: height})
 	}
 
 	// branch the commit-multistore for safety
@@ -892,7 +888,7 @@ func handleQueryCustom(app *BaseApp, path []string, req abci.RequestQuery) abci.
 		return sdkerrors.QueryResult(sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "no custom querier found for route %s", path[1]), app.trace)
 	}
 
-	ctx, err := app.createQueryContext(req.Height, req.Prove)
+	ctx, err := app.CreateQueryContext(req.Height, req.Prove)
 	if err != nil {
 		return sdkerrors.QueryResult(err, app.trace)
 	}

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -659,7 +659,7 @@ func checkNegativeHeight(height int64) error {
 	return nil
 }
 
-// createQueryContext creates a new sdk.Context for a query, taking as args
+// CreateQueryContext creates a new sdk.Context for a query, taking as args
 // the block height and whether the query needs a proof or not.
 func (app *BaseApp) CreateQueryContext(height int64, prove bool) (sdk.Context, error) {
 	if err := checkNegativeHeight(height); err != nil {

--- a/baseapp/abci_test.go
+++ b/baseapp/abci_test.go
@@ -157,7 +157,7 @@ func TestBaseAppCreateQueryContext(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := app.createQueryContext(tc.height, tc.prove)
+			_, err := app.CreateQueryContext(tc.height, tc.prove)
 			if tc.expErr {
 				require.Error(t, err)
 			} else {

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -228,7 +228,6 @@ func (app *BaseApp) GetAppVersionFromParamStore(ctx sdk.Context) uint64 {
 	if app.paramStore.Has(ctx, ParamStoreKeyVersionParams) {
 		var vp tmproto.VersionParams
 		app.paramStore.Get(ctx, ParamStoreKeyVersionParams, &vp)
-		// set the app version
 		return vp.AppVersion
 	}
 	return 0

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -223,12 +223,22 @@ func (app *BaseApp) Name() string {
 	return app.name
 }
 
-func (app *BaseApp) InitAppVersion(ctx sdk.Context) {
-	if app.appVersion == 0 && app.paramStore.Has(ctx, ParamStoreKeyVersionParams) {
+// GetAppVersionFromParamStore returns the app version from the param store.
+func (app *BaseApp) GetAppVersionFromParamStore(ctx sdk.Context) uint64 {
+	if app.paramStore.Has(ctx, ParamStoreKeyVersionParams) {
 		var vp tmproto.VersionParams
 		app.paramStore.Get(ctx, ParamStoreKeyVersionParams, &vp)
 		// set the app version
-		app.appVersion = vp.AppVersion
+		return vp.AppVersion
+	}
+	return 0
+}
+
+// SetInitialAppVersionInConsensusParams sets the initial app version
+// in the consensus params if it has not yet been set.
+func (app *BaseApp) SetInitialAppVersionInConsensusParams(ctx sdk.Context, version uint64) {
+	if !app.paramStore.Has(ctx, ParamStoreKeyVersionParams) {
+		app.paramStore.Set(ctx, ParamStoreKeyVersionParams, &tmproto.VersionParams{AppVersion: version})
 	}
 }
 
@@ -543,14 +553,6 @@ func (app *BaseApp) StoreConsensusParams(ctx sdk.Context, cp *abci.ConsensusPara
 	app.paramStore.Set(ctx, ParamStoreKeyValidatorParams, cp.Validator)
 	if app.paramStore.Has(ctx, ParamStoreKeyVersionParams) {
 		app.paramStore.Set(ctx, ParamStoreKeyVersionParams, cp.Version)
-	}
-}
-
-// SetInitialAppVersionInConsensusParams sets the initial app version
-// in the consensus params if it has not yet been set.
-func (app *BaseApp) SetInitialAppVersionInConsensusParams(ctx sdk.Context, version uint64) {
-	if !app.paramStore.Has(ctx, ParamStoreKeyVersionParams) {
-		app.paramStore.Set(ctx, ParamStoreKeyVersionParams, &tmproto.VersionParams{AppVersion: version})
 	}
 }
 

--- a/baseapp/grpcserver.go
+++ b/baseapp/grpcserver.go
@@ -47,7 +47,7 @@ func (app *BaseApp) RegisterGRPCServer(server gogogrpc.Server) {
 
 		// Create the sdk.Context. Passing false as 2nd arg, as we can't
 		// actually support proofs with gRPC right now.
-		sdkCtx, err := app.createQueryContext(height, false)
+		sdkCtx, err := app.CreateQueryContext(height, false)
 		if err != nil {
 			return nil, err
 		}

--- a/baseapp/util_test.go
+++ b/baseapp/util_test.go
@@ -53,13 +53,6 @@ func (app *BaseApp) GetName() string {
 	return app.name
 }
 
-// CreateQueryContext calls app's createQueryContext.
-//
-// This method is only accessible in baseapp tests.
-func (app *BaseApp) CreateQueryContext(height int64, prove bool) (types.Context, error) {
-	return app.createQueryContext(height, prove)
-}
-
 // MinGasPrices returns minGasPrices.
 //
 // This method is only accessible in baseapp tests.


### PR DESCRIPTION
## Description

This add the necessary API to fix the bug with restarting the application that was caused by not being able to correctly set the app version