### PR TITLE
fix: initialising of check tx state

### DIFF
--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -10,6 +10,7 @@ import (
 	"github.com/tendermint/tendermint/crypto/tmhash"
 	"github.com/tendermint/tendermint/libs/log"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+	"github.com/tendermint/tendermint/proto/tendermint/version"
 	dbm "github.com/tendermint/tm-db"
 
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
@@ -408,7 +409,12 @@ func (app *BaseApp) Init() error {
 	}
 
 	// needed for the export command which inits from store but never calls initchain
-	app.setCheckState(tmproto.Header{})
+	app.setCheckState(tmproto.Header{
+		Version: version.Consensus{
+			App: app.appVersion,
+		},
+		Height: app.LastBlockHeight(),
+	})
 	app.Seal()
 
 	if app.cms == nil {


### PR DESCRIPTION
When restarting, before the next height get's committed, all transactions were being rejected in check tx because the app version was still set to 0.

We were correctly loading the app version but not applying it to check tx state. This PR fixes this