### PR TITLE
feat: expose `config.IsSealed`

### DIFF
--- a/types/config.go
+++ b/types/config.go
@@ -82,6 +82,13 @@ func (config *Config) assertNotSealed() {
 	}
 }
 
+func (config *Config) IsSealed() bool {
+	config.mtx.Lock()
+	defer config.mtx.Unlock()
+
+	return config.sealed
+}
+
 // SetBech32PrefixForAccount builds the Config with Bech32 addressPrefix and publKeyPrefix for accounts
 // and returns the config instance
 func (config *Config) SetBech32PrefixForAccount(addressPrefix, pubKeyPrefix string) {

--- a/types/config_test.go
+++ b/types/config_test.go
@@ -68,3 +68,10 @@ func (s *configTestSuite) TestConfig_SetFullFundraiserPath() {
 func (s *configTestSuite) TestKeyringServiceName() {
 	s.Require().Equal(sdk.DefaultKeyringServiceName, sdk.KeyringServiceName())
 }
+
+func (s *configTestSuite) TestIsConfigSealed() {
+	config := sdk.NewConfig()
+	s.Require().False(config.IsSealed())
+	config.Seal()
+	s.Require().True(config.IsSealed())
+}


### PR DESCRIPTION
Expose `config.IsSealed` so that we can check it before invoking seal on it from the v2 and v3 state machine. We can remove this as soon as Cosmos SDK removes the global singleton config.