### PR TITLE
fix: emit status to stdout

### DIFF
--- a/client/rpc/status.go
+++ b/client/rpc/status.go
@@ -67,7 +67,7 @@ func StatusCommand() *cobra.Command {
 				return err
 			}
 
-			cmd.Println(string(output))
+			cmd.OutOrStdout().Write(output)
 			return nil
 		},
 	}


### PR DESCRIPTION
Part of https://github.com/celestiaorg/celestia-app/issues/3823

## Testing

After building a celestia-app binary that replaces cosmos-sdk with this, that status output goes to stdout so it can be piped to jq easily. In other words, this works:

```
$ ./build/celestia-appd status | jq .
```