### PR TITLE
fix: enable starting of gRPC server without starting block api

### DIFF
--- a/server/grpc/server.go
+++ b/server/grpc/server.go
@@ -19,6 +19,8 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
+const tmFlag = "with-tendermint"
+
 // StartGRPCServer starts a gRPC server on the given address.
 func StartGRPCServer(clientCtx client.Context, app types.Application, cfg config.GRPCConfig) (*grpc.Server, error) {
 	maxSendMsgSize := cfg.MaxSendMsgSize
@@ -37,10 +39,12 @@ func StartGRPCServer(clientCtx client.Context, app types.Application, cfg config
 		grpc.MaxRecvMsgSize(maxRecvMsgSize),
 	)
 
-	// start the gRPC block API
-	api := coregrpc.NewBlockAPI()
-	go api.StartNewBlockEventListener(context.Background())
-	coregrpc.RegisterBlockAPIServer(grpcSrv, api)
+	if isInProcessTm(clientCtx) {
+		// start the gRPC block API only if running alongside an in-process tendermint node.
+		api := coregrpc.NewBlockAPI()
+		go api.StartNewBlockEventListener(context.Background())
+		coregrpc.RegisterBlockAPIServer(grpcSrv, api)
+	}
 
 	// start the gRPC blobstream API
 	coregrpc.RegisterBlobstreamAPIServer(grpcSrv, coregrpc.NewBlobstreamAPI())
@@ -91,4 +95,12 @@ func StartGRPCServer(clientCtx client.Context, app types.Application, cfg config
 		// assume server started successfully
 		return grpcSrv, nil
 	}
+}
+
+// isInProcessTm checks if the client is configured to run alongside an in-process Tendermint node.
+func isInProcessTm(clientCtx client.Context) bool {
+	if clientCtx.Viper == nil {
+		return false
+	}
+	return clientCtx.Viper.GetBool(tmFlag)
 }


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

In order for the multiplexer to work, the embedded binaries must be able to start a grpc server without a comet node (as that is created by the multiplexer and shared with the embedded binaries). The current code panics if you try to start a gRPC server without a local comet node present.

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
