### PR TITLE
fix!: set default keyring backend to test

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The fork include the following changes compared to upstream:
 * The x/slashing key prefix for validator missed block bitmap has been changed from `0x02` to `0x12`
 * The celestia-core celestia-core `BlockAPI` is exposed through the app grpc server. When running in standalone mode the app uses a proxy service to maintain support through same the app grpc port.
 * The default listen address for remote ABCI connections over grpc has been updated from `tcp://127.0.0.1:26658` to `tcp://127.0.0.1:36658`.
+* The default keyring backend has been changed from `os` to `test`.
 
 Read the [CHANGELOG.md](CHANGELOG.md) for more details.
 

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -11,7 +11,7 @@ import (
 func DefaultConfig() *ClientConfig {
 	return &ClientConfig{
 		ChainID:        "",
-		KeyringBackend: "os",
+		KeyringBackend: "test",
 		Output:         "text",
 		Node:           "tcp://localhost:26657",
 		BroadcastMode:  "sync",

--- a/client/config/config_test.go
+++ b/client/config/config_test.go
@@ -93,3 +93,11 @@ func TestConfigCmdEnvFlag(t *testing.T) {
 		})
 	}
 }
+
+func TestDefaultConfig(t *testing.T) {
+	got := config.DefaultConfig()
+
+	t.Run("KeyringBackend should be test", func(t *testing.T) {
+		require.Equal(t, "test", got.KeyringBackend)
+	})
+}

--- a/client/flags/flags.go
+++ b/client/flags/flags.go
@@ -19,7 +19,7 @@ const (
 	GasFlagAuto          = "auto"
 
 	// DefaultKeyringBackend
-	DefaultKeyringBackend = keyring.BackendOS
+	DefaultKeyringBackend = keyring.BackendTest
 
 	// BroadcastSync defines a tx broadcasting mode where the client waits for
 	// a CheckTx execution response only.

--- a/client/flags/flags_test.go
+++ b/client/flags/flags_test.go
@@ -36,3 +36,9 @@ func TestParseGasSetting(t *testing.T) {
 		})
 	}
 }
+
+func TestDefaults(t *testing.T) {
+	t.Run("DefaultKeyringBackend should be test", func(t *testing.T) {
+		require.Equal(t, "test", flags.DefaultKeyringBackend)
+	})
+}


### PR DESCRIPTION
Closes https://github.com/celestiaorg/cosmos-sdk/issues/636 to match the behavior on v0.46.x-celestia