### PR TITLE
chore: distribution fix flups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -371,7 +371,7 @@ benchmark:
 ###                                Linting                                  ###
 ###############################################################################
 
-golangci_version=v1.51.2
+golangci_version=v1.60.1
 
 lint-install:
 	@echo "--> Installing golangci-lint $(golangci_version)"

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The fork include the following changes compared to upstream:
 * The celestia-core celestia-core `BlockAPI` is exposed through the app grpc server. When running in standalone mode the app uses a proxy service to maintain support through same the app grpc port.
 * The default listen address for remote ABCI connections over grpc has been updated from `tcp://127.0.0.1:26658` to `tcp://127.0.0.1:36658`.
 * The default keyring backend has been changed from `os` to `test`.
+* Rewards from the x/distribution module are not auto claimed. Instead, they can be claimed at arbitrary points in time.
 
 Read the [CHANGELOG.md](CHANGELOG.md) for more details.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The fork include the following changes compared to upstream:
 * The celestia-core celestia-core `BlockAPI` is exposed through the app grpc server. When running in standalone mode the app uses a proxy service to maintain support through same the app grpc port.
 * The default listen address for remote ABCI connections over grpc has been updated from `tcp://127.0.0.1:26658` to `tcp://127.0.0.1:36658`.
 * The default keyring backend has been changed from `os` to `test`.
-* Rewards from the x/distribution module are not auto claimed. Instead, they can be claimed at arbitrary points in time.
+* Rewards from the x/distribution module are not auto-claimed. Instead, they can be claimed at arbitrary points in time.
 
 Read the [CHANGELOG.md](CHANGELOG.md) for more details.
 

--- a/tests/integration/distribution/keeper/msg_server_test.go
+++ b/tests/integration/distribution/keeper/msg_server_test.go
@@ -1057,6 +1057,9 @@ func TestCannotDepositIfRewardPoolFull(t *testing.T) {
 	)
 	assert.NilError(t, err)
 
+	// transfer tokens from distribution module back to the account for the second deposit
+	assert.NilError(t, f.bankKeeper.SendCoinsFromModuleToAccount(f.sdkCtx, distrtypes.ModuleName, sdk.AccAddress(operatorAddr), maxCoins))
+
 	// this should fail since this amount cannot be added to the previous amount without overflowing.
 	_, err = f.app.RunMsg(
 		fundValMsg,


### PR DESCRIPTION
## Description

applies two flups, and update the linter
