### PR TITLE
fix(x/gov): allow voting period to match expedited voting period

### DIFF
--- a/x/gov/types/v1/params.go
+++ b/x/gov/types/v1/params.go
@@ -187,7 +187,7 @@ func (p Params) ValidateBasic() error {
 		return fmt.Errorf("expedited voting period must be positive: %s", p.ExpeditedVotingPeriod)
 	}
 	if p.ExpeditedVotingPeriod.Seconds() > p.VotingPeriod.Seconds() {
-		return fmt.Errorf("expedited voting period %s must be strictly less that the regular voting period %s", p.ExpeditedVotingPeriod, p.VotingPeriod)
+		return fmt.Errorf("expedited voting period %s must be less that the regular voting period %s", p.ExpeditedVotingPeriod, p.VotingPeriod)
 	}
 
 	minInitialDepositRatio, err := sdkmath.LegacyNewDecFromStr(p.MinInitialDepositRatio)

--- a/x/gov/types/v1/params.go
+++ b/x/gov/types/v1/params.go
@@ -186,7 +186,7 @@ func (p Params) ValidateBasic() error {
 	if p.ExpeditedVotingPeriod.Seconds() <= 0 {
 		return fmt.Errorf("expedited voting period must be positive: %s", p.ExpeditedVotingPeriod)
 	}
-	if p.ExpeditedVotingPeriod.Seconds() >= p.VotingPeriod.Seconds() {
+	if p.ExpeditedVotingPeriod.Seconds() > p.VotingPeriod.Seconds() {
 		return fmt.Errorf("expedited voting period %s must be strictly less that the regular voting period %s", p.ExpeditedVotingPeriod, p.VotingPeriod)
 	}
 

--- a/x/gov/types/v1/params_test.go
+++ b/x/gov/types/v1/params_test.go
@@ -1,0 +1,22 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateBasic(t *testing.T) {
+	t.Run("default params should pass ValidateBasic", func(t *testing.T) {
+		params := DefaultParams()
+		err := params.ValidateBasic()
+		require.NoError(t, err)
+	})
+
+	t.Run("params with expedited voting period equal to voting period should pass ValidateBasic", func(t *testing.T) {
+		params := DefaultParams()
+		params.ExpeditedVotingPeriod = params.VotingPeriod
+		err := params.ValidateBasic()
+		require.NoError(t, err)
+	})
+}

--- a/x/gov/types/v1/params_test.go
+++ b/x/gov/types/v1/params_test.go
@@ -2,21 +2,35 @@ package v1
 
 import (
 	"testing"
+	time "time"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestValidateBasic(t *testing.T) {
-	t.Run("default params should pass ValidateBasic", func(t *testing.T) {
+	t.Run("default params should pass", func(t *testing.T) {
 		params := DefaultParams()
 		err := params.ValidateBasic()
 		require.NoError(t, err)
 	})
 
-	t.Run("params with expedited voting period equal to voting period should pass ValidateBasic", func(t *testing.T) {
+	t.Run("params with voting period == expedited voting period should pass", func(t *testing.T) {
 		params := DefaultParams()
 		params.ExpeditedVotingPeriod = params.VotingPeriod
 		err := params.ValidateBasic()
 		require.NoError(t, err)
+	})
+
+	t.Run("params with voting period less than expedited voting period should fail", func(t *testing.T) {
+		params := DefaultParams()
+
+		oneHour := time.Hour
+		params.VotingPeriod = &oneHour
+
+		twoHours := 2 * time.Hour
+		params.ExpeditedVotingPeriod = &twoHours
+
+		err := params.ValidateBasic()
+		require.Error(t, err)
 	})
 }


### PR DESCRIPTION
Resolves https://github.com/celestiaorg/celestia-app/issues/4196#issuecomment-3282511848

## TLDR

I tried to modify the gov params on Mocha to match Mainnet with one exception: the voting period on Mocha should be **1 day** and the voting period on Mainnet should be **1 week**.

Unfortunately, there is a `ValidateBasic` in cosmos-sdk that fails if the voting period == the expedited voting period. This PR modifies that check so that they can both be 1 day on Mocha.

Note: they're already both 1 day on Arabica so this validation wasn't hit there.