### PR TITLE
chore: remove evidence constraint on pruning

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -1323,10 +1323,6 @@ func (app *BaseApp) CreateQueryContext(height int64, prove bool) (sdk.Context, e
 // minRetainBlocks configuration, the retentionHeight is the smallest height that
 // satisfies:
 //
-// - Unbonding (safety threshold) time: The block interval in which validators
-// can be economically punished for misbehavior. Blocks in this interval must be
-// auditable e.g. by the light client.
-//
 // - Logical store snapshot interval: The block interval at which the underlying
 // logical store database is persisted to disk, e.g. every 10000 heights. Blocks
 // since the last IAVL snapshot must be available for replay on application restart.
@@ -1365,16 +1361,6 @@ func (app *BaseApp) GetBlockRetentionHeight(commitHeight int64) int64 {
 	// constraints. All blocks below (commitHeight-retentionHeight) are pruned
 	// from CometBFT.
 	var retentionHeight int64
-
-	// Define the number of blocks needed to protect against misbehaving validators
-	// which allows light clients to operate safely. Note, we piggy back of the
-	// evidence parameters instead of computing an estimated number of blocks based
-	// on the unbonding period and block commitment time as the two should be
-	// equivalent.
-	cp := app.GetConsensusParams(app.finalizeBlockState.Context())
-	if cp.Evidence != nil && cp.Evidence.MaxAgeNumBlocks > 0 {
-		retentionHeight = commitHeight - cp.Evidence.MaxAgeNumBlocks
-	}
 
 	if app.snapshotManager != nil {
 		snapshotRetentionHeights := app.snapshotManager.GetSnapshotBlockRetentionHeights()

--- a/baseapp/abci_test.go
+++ b/baseapp/abci_test.go
@@ -1279,11 +1279,11 @@ func TestABCI_GetBlockRetentionHeight(t *testing.T) {
 			commitHeight: 499000,
 			expected:     0,
 		},
-		"pruning unbonding time only": {
+		"pruning min retention with evidence age set": {
 			bapp:         baseapp.NewBaseApp(name, logger, db, nil, baseapp.SetMinRetainBlocks(1)),
 			maxAgeBlocks: 362880,
 			commitHeight: 499000,
-			expected:     136120,
+			expected:     498999,
 		},
 		"pruning iavl snapshot only": {
 			bapp: baseapp.NewBaseApp(
@@ -1322,7 +1322,7 @@ func TestABCI_GetBlockRetentionHeight(t *testing.T) {
 				baseapp.SetMinRetainBlocks(400000),
 				baseapp.SetSnapshot(snapshotStore, snapshottypes.NewSnapshotOptions(50000, 3)),
 			),
-			maxAgeBlocks: 362880,
+			maxAgeBlocks: 0,
 			commitHeight: 499000,
 			expected:     99000,
 		},
@@ -1333,7 +1333,7 @@ func TestABCI_GetBlockRetentionHeight(t *testing.T) {
 				baseapp.SetMinRetainBlocks(400000),
 				baseapp.SetSnapshot(snapshotStore, snapshottypes.NewSnapshotOptions(50000, 3)),
 			),
-			maxAgeBlocks: 362880,
+			maxAgeBlocks: 0,
 			commitHeight: 10000,
 			expected:     0,
 		},
@@ -1344,9 +1344,37 @@ func TestABCI_GetBlockRetentionHeight(t *testing.T) {
 				baseapp.SetMinRetainBlocks(0),
 				baseapp.SetSnapshot(snapshotStore, snapshottypes.NewSnapshotOptions(50000, 3)),
 			),
-			maxAgeBlocks: 362880,
+			maxAgeBlocks: 0,
 			commitHeight: 499000,
 			expected:     0,
+		},
+		"aggressive pruning with evidence age set": {
+			bapp: baseapp.NewBaseApp(
+				name, logger, db, nil,
+				baseapp.SetMinRetainBlocks(1000),
+			),
+			maxAgeBlocks: 362880,
+			commitHeight: 499000,
+			expected:     498000,
+		},
+		"evidence age ignored when minRetainBlocks is lower": {
+			bapp: baseapp.NewBaseApp(
+				name, logger, db, nil,
+				baseapp.SetMinRetainBlocks(10000),
+			),
+			maxAgeBlocks: 362880,
+			commitHeight: 499000,
+			expected:     489000,
+		},
+		"minRetainBlocks takes precedence when more restrictive": {
+			bapp: baseapp.NewBaseApp(
+				name, logger, db, nil,
+				baseapp.SetMinRetainBlocks(100000),
+				baseapp.SetSnapshot(snapshotStore, snapshottypes.NewSnapshotOptions(10000, 1)),
+			),
+			maxAgeBlocks: 362880,
+			commitHeight: 499000,
+			expected:     399000,
 		},
 	}
 

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -70,9 +70,8 @@ type BaseConfig struct {
 	// "pruning-*" configurations.
 	//
 	// Note: CometBFT block pruning is dependant on this parameter in conjunction
-	// with the unbonding (safety threshold) period, state pruning and state sync
-	// snapshot parameters to determine the correct minimum value of
-	// ResponseCommit.RetainHeight.
+	// with state pruning and state sync snapshot parameters to determine the
+	// correct minimum value of ResponseCommit.RetainHeight.
 	MinRetainBlocks uint64 `mapstructure:"min-retain-blocks"`
 
 	// InterBlockCache enables inter-block caching.


### PR DESCRIPTION
Closes https://github.com/celestiaorg/cosmos-sdk/issues/699

Removes the evidence constraint from block pruning. This means the consensus node can prune blocks within the evidence window.

The state sync constraint was preserved so nodes won't prune blocks within their state sync snapshot window.

Nodes won't prune any blocks if their app.toml has `min-retain-blocks: 0` so as a FLUP, we should consider setting that to something non-zero. Opened https://github.com/celestiaorg/celestia-app/issues/6315