### PR TITLE
chore: bump Go version from 1.24.11 to 1.24.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-go 1.24.11
+go 1.24.13
 
 module github.com/cosmos/cosmos-sdk
 

--- a/simapp/go.mod
+++ b/simapp/go.mod
@@ -1,6 +1,6 @@
 module cosmossdk.io/simapp
 
-go 1.24.11
+go 1.24.13
 
 require (
 	cosmossdk.io/api v0.7.6

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/cosmos/cosmos-sdk/tests
 
-go 1.24.11
+go 1.24.13
 
 require (
 	cosmossdk.io/api v0.7.6

--- a/x/upgrade/go.mod
+++ b/x/upgrade/go.mod
@@ -1,6 +1,6 @@
 module cosmossdk.io/x/upgrade
 
-go 1.24.11
+go 1.24.13
 
 require (
 	cosmossdk.io/api v0.7.6


### PR DESCRIPTION
## Summary

Bump Go version from 1.24.11 to 1.24.13 in all 4 `go.mod` files (root, simapp, tests, x/upgrade).

Go 1.24.13 fixes three stdlib vulnerabilities that cause `make vulncheck` (govulncheck) to fail on every PR:

- [GO-2026-4341](https://pkg.go.dev/vuln/GO-2026-4341): memory exhaustion in `net/url` query parameter parsing
- [GO-2026-4340](https://pkg.go.dev/vuln/GO-2026-4340): handshake messages at incorrect encryption level in `crypto/tls`
- [GO-2026-4337](https://pkg.go.dev/vuln/GO-2026-4337): unexpected session resumption in `crypto/tls`

## Test plan

- [ ] `dependency-review` CI job passes (govulncheck no longer flags Go stdlib vulns)
- [ ] All other CI checks continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)