### PR TITLE
docs: add SECURITY.md with bug bounty link

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+**Please do not file a public ticket** mentioning the vulnerability.
+
+To disclose a vulnerability, please submit a `Security Advisory` via the
+`Security` tab on this repository. If security reporting is not available,
+please email `security@celestia.org`.
+
+## Bug Bounty
+
+Vulnerabilities may be eligible for a reward through Celestia's bug bounty
+program on [HackenProof](https://hackenproof.com/programs/celestia). If you
+believe the vulnerability qualifies for a bounty, please report it through
+HackenProof first.


### PR DESCRIPTION
Closes #713

Add a security policy that directs vulnerability reporters to use GitHub Security Advisories and includes a link to Celestia's bug bounty program on HackenProof. This replaces the upstream Cosmos security policy that was removed in PR #711.