### PR TITLE
fix: protect lastCommitInfo race at baseapp level

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -961,7 +961,17 @@ func (app *BaseApp) Commit() (*abci.ResponseCommit, error) {
 		rms.SetCommitHeader(header)
 	}
 
+	// Hold the write lock across both the store commit and the check state
+	// reset. This prevents data races with concurrent gRPC queries that read
+	// LatestVersion() and checkState in CreateQueryContext(). The store's
+	// cms.Commit() writes lastCommitInfo which is read by LatestVersion().
+	//
+	// NOTE: This is safe because CometBFT holds a lock on the mempool for
+	// Commit. Use the header from this latest block.
+	app.checkStateMu.Lock()
 	app.cms.Commit()
+	app.setState(execModeCheck, header)
+	app.checkStateMu.Unlock()
 
 	resp := &abci.ResponseCommit{
 		RetainHeight: retainHeight,
@@ -979,14 +989,6 @@ func (app *BaseApp) Commit() (*abci.ResponseCommit, error) {
 			}
 		}
 	}
-
-	// Reset the CheckTx state to the latest committed.
-	//
-	// NOTE: This is safe because CometBFT holds a lock on the mempool for
-	// Commit. Use the header from this latest block.
-	app.checkStateMu.Lock()
-	app.setState(execModeCheck, header)
-	app.checkStateMu.Unlock()
 
 	app.finalizeBlockState = nil
 
@@ -1264,7 +1266,15 @@ func (app *BaseApp) CreateQueryContext(height int64, prove bool) (sdk.Context, e
 		qms = app.cms.(storetypes.MultiStore)
 	}
 
+	// Hold checkStateMu.RLock across both the LatestVersion() read and the
+	// checkState header read. Commit() updates both the store's lastCommitInfo
+	// (read by LatestVersion) and checkState under the corresponding write lock,
+	// so this prevents data races with concurrent block commits.
+	app.checkStateMu.RLock()
 	lastBlockHeight := qms.LatestVersion()
+	header := app.checkState.Context().BlockHeader()
+	app.checkStateMu.RUnlock()
+
 	if lastBlockHeight == 0 {
 		return sdk.Context{}, errorsmod.Wrapf(sdkerrors.ErrInvalidHeight, "%s is not ready; please wait for first block", app.Name())
 	}
@@ -1298,11 +1308,6 @@ func (app *BaseApp) CreateQueryContext(height int64, prove bool) (sdk.Context, e
 				"failed to load state at height %d; %s (latest height: %d)", height, err, lastBlockHeight,
 			)
 	}
-
-	// branch the commit multi-store for safety
-	app.checkStateMu.RLock()
-	header := app.checkState.Context().BlockHeader()
-	app.checkStateMu.RUnlock()
 	ctx := sdk.NewContext(cacheMS, header, true, app.logger).
 		WithMinGasPrices(app.minGasPrices).
 		WithGasMeter(storetypes.NewGasMeter(app.queryGasLimit)).


### PR DESCRIPTION
## Summary

- Fixes a data race between `Commit()` and `CreateQueryContext()` that persists for downstream consumers (celestia-app) despite the store-level fix in #705
- The store-level mutex on `lastCommitInfo` isn't effective for celestia-app because `cosmossdk.io/store` is a separate Go module and Go replace directives aren't transitive — celestia-app uses upstream `store@v1.1.2` which has no mutex
- Extends `checkStateMu` to cover `cms.Commit()` alongside `setState()`, preventing the race at the baseapp level regardless of which store module is used

## Details

In `Commit()`, the write lock now spans both:
1. `app.cms.Commit()` (writes `lastCommitInfo`)
2. `app.setState(execModeCheck, header)` (writes `checkState`)

In `CreateQueryContext()`, the read lock now spans both:
1. `qms.LatestVersion()` (reads `lastCommitInfo`)
2. `app.checkState.Context().BlockHeader()` (reads `checkState`)

### Test results

`TestCommitCreateQueryContextRace` with `-race -count=10`:

| Store mutex | Baseapp fix | Race detected? |
|---|---|---|
| Removed | Absent | **YES** |
| Removed | Present | No |
| Present | Present | No |

## Test plan

- [x] `go test -race -run TestCommitCreateQueryContextRace -count=10` passes with store mutex removed (simulating upstream store@v1.1.2)
- [x] `go test -race -run TestCommitCreateQueryContextRace -count=10` passes with both fixes
- [x] Relevant baseapp tests pass with race detector

Closes https://github.com/celestiaorg/celestia-app/issues/6614

🤖 Generated with [Claude Code](https://claude.com/claude-code)