### PR TITLE
fix: data race in x/tx signing Context.GetSigners

### DIFF
--- a/x/tx/signing/context.go
+++ b/x/tx/signing/context.go
@@ -309,6 +309,7 @@ func (c *Context) makeGetSignersFunc(descriptor protoreflect.MessageDescriptor) 
 	return func(message proto.Message) ([][]byte, error) {
 		var signers [][]byte
 		for _, getter := range fieldGetters {
+			var err error
 			signers, err = getter(message, signers)
 			if err != nil {
 				return nil, err

--- a/x/tx/signing/context_test.go
+++ b/x/tx/signing/context_test.go
@@ -66,6 +66,37 @@ func TestGetGetSignersFnConcurrent(t *testing.T) {
 	}
 }
 
+// TestGetSignersConcurrent verifies that calling GetSigners concurrently on the
+// same message type does not trigger a data race. This is a regression test for
+// a bug where the closure returned by makeGetSignersFunc captured a shared err
+// variable from the outer function scope, causing concurrent writes.
+// See https://github.com/celestiaorg/celestia-app/issues/6757
+func TestGetSignersConcurrent(t *testing.T) {
+	ctx, err := NewContext(Options{
+		AddressCodec:          dummyAddressCodec{},
+		ValidatorAddressCodec: dummyValidatorAddressCodec{},
+	})
+	require.NoError(t, err)
+
+	msg := &bankv1beta1.MsgSend{
+		FromAddress: hex.EncodeToString([]byte("foo")),
+	}
+	// Prime the cache so all goroutines share the same closure.
+	_, err = ctx.GetSigners(msg)
+	require.NoError(t, err)
+
+	errs := make(chan error, 100)
+	for i := 0; i < 100; i++ {
+		go func() {
+			_, err := ctx.GetSigners(msg)
+			errs <- err
+		}()
+	}
+	for i := 0; i < 100; i++ {
+		require.NoError(t, <-errs)
+	}
+}
+
 func TestGetSigners(t *testing.T) {
 	ctx, err := NewContext(Options{
 		AddressCodec:          dummyAddressCodec{},


### PR DESCRIPTION
## Summary

Fixes a data race in `x/tx/signing/context.go` that causes `test-race` failures in celestia-app.

- The closure returned by `makeGetSignersFunc` captured a shared `err` variable from the outer function scope
- When multiple goroutines called `GetSigners` concurrently on the same message type, they wrote to the same `err` variable, triggering a data race
- Fix: declare `err` as a local variable inside the closure

Closes https://github.com/celestiaorg/celestia-app/issues/6757

## Test plan

- [x] Added `TestGetSignersConcurrent` regression test that reproduces the race
- [x] Verified the test fails with `-race` before the fix (`go test -race -run TestGetSignersConcurrent -count=5`)
- [x] Verified the test passes with `-race` after the fix (`go test -race -run TestGetSignersConcurrent -count=10`)
- [x] Verified all existing tests in `x/tx/signing` continue to pass

## Follow-up steps after merge

To fully resolve the nightly `test-race` failure in celestia-app:

1. Create a new release tag for `cosmossdk.io/x/tx` from this repo (e.g. tag `x/tx/v0.13.9` on the `release/v0.52.x-celestia` branch)
2. In `celestia-app`, update `go.mod` to use the new version: `cosmossdk.io/x/tx v0.13.9`
3. Run `go mod tidy` and verify `test-race` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)