### PR TITLE
fix: increase LatestHeight timeout from 5s to 30s

### DIFF
--- a/testutil/network/network.go
+++ b/testutil/network/network.go
@@ -668,7 +668,7 @@ func (n *Network) LatestHeight() (int64, error) {
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
 
-	timeout := time.NewTimer(time.Second * 5)
+	timeout := time.NewTimer(time.Second * 30)
 	defer timeout.Stop()
 
 	var latestHeight int64


### PR DESCRIPTION
## Summary
- Increase `LatestHeight()` timeout from 5s to 30s in `testutil/network/network.go`
- The 5-second timeout was too aggressive for CI environments with `-race` detector enabled
- This fixes intermittent "timeout exceeded waiting for block" failures in test-e2e

The race detector adds significant overhead to node startup. With only 5 seconds, the validators sometimes couldn't produce the first block in time, causing the e2e auth test suite to fail intermittently.

The 30-second timeout is still a reasonable upper bound — if a node genuinely can't produce a block in 30 seconds, there's a real problem.

## Test plan
- [ ] `test-e2e` CI job passes consistently
- [ ] Verified the timeout only affects initial startup check, not ongoing test speed

Closes #721

🤖 Generated with [Claude Code](https://claude.com/claude-code)