### PR TITLE
fix: data race between Simulate and Commit in IAVL tree

### DIFF
--- a/baseapp/baseapp_test.go
+++ b/baseapp/baseapp_test.go
@@ -873,6 +873,61 @@ func TestCommitCreateQueryContextRace(t *testing.T) {
 	wg.Wait()
 }
 
+// TestCommitSimulateRace reproduces a data race between Commit() writing to
+// the IAVL tree via SaveVersion() and Simulate() reading the IAVL tree via
+// getContextForTx/GetConsensusParams and subsequent message execution.
+// See https://github.com/celestiaorg/cosmos-sdk/issues/725
+func TestCommitSimulateRace(t *testing.T) {
+	db := dbm.NewMemDB()
+	app := baseapp.NewBaseApp(t.Name(), log.NewTestLogger(t), db, nil)
+
+	_, err := app.FinalizeBlock(&abci.RequestFinalizeBlock{Height: 1})
+	require.NoError(t, err)
+	_, err = app.Commit()
+	require.NoError(t, err)
+
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Writer goroutine: repeatedly finalize + commit blocks.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for height := int64(2); ; height++ {
+			select {
+			case <-done:
+				return
+			default:
+			}
+			_, _ = app.FinalizeBlock(&abci.RequestFinalizeBlock{Height: height})
+			_, _ = app.Commit()
+		}
+	}()
+
+	// Reader goroutines: repeatedly call Simulate which reads checkState and
+	// the IAVL tree.
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-done:
+					return
+				default:
+				}
+				// txBytes can be nil; Simulate will fail to decode but the
+				// race occurs before decoding, in getContextForTx.
+				_, _, _ = app.Simulate(nil)
+			}
+		}()
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	close(done)
+	wg.Wait()
+}
+
 func TestSetMinGasPrices(t *testing.T) {
 	minGasPrices := sdk.DecCoins{sdk.NewInt64DecCoin("stake", 5000)}
 	suite := NewBaseAppSuite(t, baseapp.SetMinGasPrices(minGasPrices.String()))

--- a/baseapp/test_helpers.go
+++ b/baseapp/test_helpers.go
@@ -25,7 +25,16 @@ func (app *BaseApp) SimCheck(txEncoder sdk.TxEncoder, tx sdk.Tx) (sdk.GasInfo, *
 
 // Simulate executes a tx in simulate mode to get result and gas info.
 func (app *BaseApp) Simulate(txBytes []byte) (sdk.GasInfo, *sdk.Result, error) {
+	// Hold the read lock for the entire simulation. Commit() acquires the
+	// write lock while it calls cms.Commit() (which mutates the IAVL tree via
+	// SaveVersion) and resets checkState. Simulate reads checkState in
+	// getContextForTx and then reads the IAVL tree throughout runTx, so the
+	// read lock prevents a data race with concurrent block commits. Multiple
+	// concurrent Simulate calls can still proceed since they only take a
+	// read lock.
+	app.checkStateMu.RLock()
 	gasInfo, result, _, _, err := app.runTx(execModeSimulate, txBytes)
+	app.checkStateMu.RUnlock()
 	return gasInfo, result, err
 }
 


### PR DESCRIPTION
## Summary

- Fixes a data race between `BaseApp.Simulate()` and `BaseApp.Commit()` where `Simulate` reads `checkState` and the IAVL tree concurrently with `Commit` writing to them via `SaveVersion()` and `setState()`
- Holds `checkStateMu.RLock` for the duration of `Simulate()`, preventing it from running concurrently with Commit's write-locked critical section while still allowing multiple concurrent `Simulate` calls
- Adds `TestCommitSimulateRace` regression test that fails with `-race` before the fix and passes after

## Details

PR #715 added `checkStateMu` to protect `CreateQueryContext()` from racing with `Commit()`. However, the `Simulate()` path goes through a different code path:

```
Simulate() → runTx(execModeSimulate) → getContextForTx() → GetConsensusParams() → IAVL Get()
```

`getContextForTx()` reads `checkState` and the IAVL tree without holding `checkStateMu`, while `Commit()` holds the write lock and calls `cms.Commit()` which writes to the IAVL tree via `SaveVersion()`.

### Race trace from celestia-app

```
Read at 0x00c005c0a420 by goroutine 1190:
  github.com/cosmos/iavl.(*MutableTree).Get()
  ...
  github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).GetConsensusParams()
  github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).getContextForTx()
  github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).runTx()
  github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).Simulate()

Previous write at 0x00c005c0a420 by goroutine 505:
  github.com/cosmos/iavl.(*MutableTree).SaveVersion()
  ...
  github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).Commit()
```

## Test plan

- [x] `go test -race -run TestCommitSimulateRace -count=5 ./baseapp/` passes
- [x] `go test -race -run TestCommitCreateQueryContextRace -count=5 ./baseapp/` still passes
- [x] Verified `TestCommitSimulateRace` fails with `-race` before the fix (by reverting the `test_helpers.go` change)

Closes https://github.com/celestiaorg/cosmos-sdk/issues/725
Closes https://github.com/celestiaorg/celestia-app/issues/6776

🤖 Generated with [Claude Code](https://claude.com/claude-code)