### PR TITLE
chore: update CODEOWNERS to use protocol team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,8 @@
-# CODEOWNERS: https://help.github.com/articles/about-codeowners/
+# CODEOWNERS: <https://help.github.com/articles/about-codeowners/>
 
-# NOTE: Order is important; the last matching pattern takes the
-# most precedence.
+# Everything goes through the protocol team by default. The team's review
+# assignment settings control how many reviewers are auto-assigned per PR.
+# See: https://github.com/orgs/celestiaorg/teams/protocol/edit/review_assignment
 
-# Primary repo maintainers
-* @celestiaorg/celestia-core
+# global owners
+* @celestiaorg/protocol


### PR DESCRIPTION
## Summary

- Update CODEOWNERS to use `@celestiaorg/protocol` team
- The protocol team's [review assignment settings](https://github.com/orgs/celestiaorg/teams/protocol/edit/review_assignment) auto-assign 1 reviewer per PR

## Context

Part of https://linear.app/celestia/issue/PROTOCO-1217/fix-codeowners-and-pr-reviews-for-protocol-maintained-repos

This was tested and works as expected on celestia-app which now has the protocol team as CODEOWNERs and a PR auto-requested a review from Vlad: https://github.com/celestiaorg/celestia-app/pull/6875

🤖 Generated with [Claude Code](https://claude.com/claude-code)