### PR TITLE
chore: add Hacken bug bounty PR guidelines to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,3 +105,7 @@ In `go.mod`, CometBFT is replaced with celestia-core:
 ```go
 github.com/cometbft/cometbft => github.com/celestiaorg/celestia-core v0.39.11
 ```
+
+## Security PRs
+
+- For PRs that resolve Hacken bug bounty reports, do not include details about the bug in the PR description. Instead, link to a Linear issue that contains more details on the bug and the link to the Hacken bug bounty report.


### PR DESCRIPTION
## Summary
- Add a "Security PRs" section to `CLAUDE.md` instructing Claude to not include bug details in PR descriptions for Hacken bug bounty fixes

Closes https://linear.app/celestia/issue/PROTOCO-1445/update-claudemd

## Test plan
- [ ] Verify `CLAUDE.md` has the new "Security PRs" section appended

🤖 Generated with [Claude Code](https://claude.com/claude-code)