### PR TITLE
fix: data race in BaseApp.LastBlockHeight and LastCommitID

### DIFF
--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -408,12 +408,22 @@ func (app *BaseApp) LoadVersion(version int64) error {
 }
 
 // LastCommitID returns the last CommitID of the multistore.
+// Holds checkStateMu.RLock so the read of rootmulti.Store.lastCommitInfo is
+// synchronized with Commit, which writes that field under the corresponding
+// write lock.
 func (app *BaseApp) LastCommitID() storetypes.CommitID {
+	app.checkStateMu.RLock()
+	defer app.checkStateMu.RUnlock()
 	return app.cms.LastCommitID()
 }
 
 // LastBlockHeight returns the last committed block height.
+// Holds checkStateMu.RLock so the read of rootmulti.Store.lastCommitInfo is
+// synchronized with Commit, which writes that field under the corresponding
+// write lock.
 func (app *BaseApp) LastBlockHeight() int64 {
+	app.checkStateMu.RLock()
+	defer app.checkStateMu.RUnlock()
 	return app.cms.LastCommitID().Version
 }
 

--- a/baseapp/baseapp_test.go
+++ b/baseapp/baseapp_test.go
@@ -928,6 +928,60 @@ func TestCommitSimulateRace(t *testing.T) {
 	wg.Wait()
 }
 
+// TestCommitLastBlockHeightRace reproduces a data race between Commit()
+// writing rootmulti.Store.lastCommitInfo and BaseApp.LastBlockHeight() /
+// BaseApp.LastCommitID() reading it without holding checkStateMu.
+// See https://github.com/celestiaorg/cosmos-sdk/issues/732
+func TestCommitLastBlockHeightRace(t *testing.T) {
+	db := dbm.NewMemDB()
+	app := baseapp.NewBaseApp(t.Name(), log.NewTestLogger(t), db, nil)
+
+	_, err := app.FinalizeBlock(&abci.RequestFinalizeBlock{Height: 1})
+	require.NoError(t, err)
+	_, err = app.Commit()
+	require.NoError(t, err)
+
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Writer goroutine: repeatedly finalize + commit blocks.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for height := int64(2); ; height++ {
+			select {
+			case <-done:
+				return
+			default:
+			}
+			_, _ = app.FinalizeBlock(&abci.RequestFinalizeBlock{Height: height})
+			_, _ = app.Commit()
+		}
+	}()
+
+	// Reader goroutines: repeatedly call LastBlockHeight and LastCommitID,
+	// which read rootmulti.Store.lastCommitInfo.
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-done:
+					return
+				default:
+				}
+				_ = app.LastBlockHeight()
+				_ = app.LastCommitID()
+			}
+		}()
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	close(done)
+	wg.Wait()
+}
+
 func TestSetMinGasPrices(t *testing.T) {
 	minGasPrices := sdk.DecCoins{sdk.NewInt64DecCoin("stake", 5000)}
 	suite := NewBaseAppSuite(t, baseapp.SetMinGasPrices(minGasPrices.String()))


### PR DESCRIPTION
## Summary

- Add `checkStateMu.RLock` to `BaseApp.LastBlockHeight()` and `BaseApp.LastCommitID()` so reads of `rootmulti.Store.lastCommitInfo` are synchronized with `Commit`.
- Add `TestCommitLastBlockHeightRace` as regression protection (follows the `TestCommitCreateQueryContextRace` / `TestCommitSimulateRace` pattern).

## Why

#715 widened `checkStateMu` to protect `Commit` and the `LatestVersion()` read inside `CreateQueryContext`, but `BaseApp.LastBlockHeight()` / `BaseApp.LastCommitID()` still read `app.cms.LastCommitID()` unlocked. Any caller on a non-consensus goroutine (e.g. a gRPC query handler) races with `Commit`.

Observed in celestia-app CI (`TestV2SubmitMethods` in `pkg/user/v2`):

\`\`\`
WARNING: DATA RACE
Write at 0x... by goroutine 472:
  cosmossdk.io/store/rootmulti.(*Store).Commit()       rootmulti/store.go:489
  baseapp.(*BaseApp).Commit()                           abci.go:972

Previous read at 0x... by goroutine 1417:
  cosmossdk.io/store/rootmulti.(*Store).LastCommitID()    rootmulti/store.go:448
  baseapp.(*BaseApp).LastBlockHeight()                    baseapp.go:417
  ... gas-estimation gRPC handler ...
\`\`\`

See celestiaorg/celestia-app#7101 and https://github.com/celestiaorg/celestia-app/actions/runs/24573914403/attempts/1?pr=7098.

## Reentrant-lock audit

\`BaseApp.Commit\` (abci.go:971-974) holds \`checkStateMu.Lock()\` across \`cms.Commit()\` + \`setState(...)\`. Neither reaches \`LastBlockHeight\` / \`LastCommitID\`, so there is no reentrant deadlock. All other in-tree callers of these two methods (ABCI handlers in \`abci.go\` at lines 139, 181, 410, 494, 735, 754 and \`validateFinalizeBlockHeight\` at \`baseapp.go:609\`) run on the consensus goroutine and never hold \`checkStateMu.Lock()\` when calling these methods.

## Test note

\`TestCommitLastBlockHeightRace\` passes even without the baseapp fix in this repo because the fork's local \`./store/rootmulti\` has its own \`lastCommitInfoMu\` (added in #705) that independently protects the field. The race fires in celestia-app because celestia-app's \`go.mod\` pulls upstream \`cosmossdk.io/store v1.1.2\` (no store-level mutex), leaving baseapp as the only lock layer. The test is therefore regression protection for the baseapp layer — matching the style of \`TestCommitCreateQueryContextRace\` and \`TestCommitSimulateRace\` shipped with #715 and #726.

## Test plan

- [x] \`go test -race -count=1 -run TestCommitLastBlockHeightRace ./baseapp/\` passes
- [x] \`go test -race -short -count=1 ./baseapp/...\` passes
- [ ] CI passes

Closes #732

🤖 Generated with [Claude Code](https://claude.com/claude-code)