### PR TITLE
feat(grpc): allow apps to register custom server interceptors

### DIFF
--- a/baseapp/grpcserver.go
+++ b/baseapp/grpcserver.go
@@ -77,11 +77,15 @@ func (app *BaseApp) RegisterGRPCServer(server gogogrpc.Server) {
 			methodHandler := method.Handler
 			newMethods[i] = grpc.MethodDesc{
 				MethodName: method.MethodName,
-				Handler: func(srv interface{}, ctx context.Context, dec func(interface{}) error, _ grpc.UnaryServerInterceptor) (interface{}, error) {
-					return methodHandler(srv, ctx, dec, grpcmiddleware.ChainUnaryServer(
+				Handler: func(srv interface{}, ctx context.Context, dec func(interface{}) error, outer grpc.UnaryServerInterceptor) (interface{}, error) {
+					chain := grpcmiddleware.ChainUnaryServer(
 						grpcrecovery.UnaryServerInterceptor(),
 						interceptor,
-					))
+					)
+					if outer != nil {
+						chain = grpcmiddleware.ChainUnaryServer(outer, chain)
+					}
+					return methodHandler(srv, ctx, dec, chain)
 				},
 			}
 		}

--- a/server/grpc/server.go
+++ b/server/grpc/server.go
@@ -19,6 +19,12 @@ import (
 	_ "github.com/cosmos/cosmos-sdk/types/tx/amino" // Import amino.proto file for reflection
 )
 
+// ExtraServerOptions is appended to the options passed to grpc.NewServer in
+// NewGRPCServer. Applications can populate this slice (for example from an
+// init function) to register additional interceptors or stats handlers
+// without forking this package.
+var ExtraServerOptions []grpc.ServerOption
+
 // NewGRPCServer returns a correctly configured and initialized gRPC server.
 // Note, the caller is responsible for starting the server. See StartGRPCServer.
 func NewGRPCServer(clientCtx client.Context, app types.Application, cfg config.GRPCConfig) (*grpc.Server, error) {
@@ -32,11 +38,13 @@ func NewGRPCServer(clientCtx client.Context, app types.Application, cfg config.G
 		maxRecvMsgSize = config.DefaultGRPCMaxRecvMsgSize
 	}
 
-	grpcSrv := grpc.NewServer(
+	serverOpts := []grpc.ServerOption{
 		grpc.ForceServerCodec(codec.NewProtoCodec(clientCtx.InterfaceRegistry).GRPCCodec()),
 		grpc.MaxSendMsgSize(maxSendMsgSize),
 		grpc.MaxRecvMsgSize(maxRecvMsgSize),
-	)
+	}
+	serverOpts = append(serverOpts, ExtraServerOptions...)
+	grpcSrv := grpc.NewServer(serverOpts...)
 
 	app.RegisterGRPCServer(grpcSrv)
 


### PR DESCRIPTION
## Description

First part of adding gRPC interceptors.
Fixes https://linear.app/celestia/issue/PROTOCO-1682/add-a-hook-so-apps-can-register-custom-grpc-server-interceptors