### PR TITLE
refactor: add the ability to pass opts in grpc server initalisation

### DIFF
--- a/server/grpc/server.go
+++ b/server/grpc/server.go
@@ -1,9 +1,13 @@
 package grpc
 
 import (
+	"context"
 	"fmt"
+	"net"
 
 	"google.golang.org/grpc"
+
+	"cosmossdk.io/log"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -15,7 +19,7 @@ import (
 	_ "github.com/cosmos/cosmos-sdk/types/tx/amino" // Import amino.proto file for reflection
 )
 
-// GRPCServerOption configures the gRPC server constructed by StartGRPCServer.
+// GRPCServerOption configures the gRPC server constructed by NewGRPCServer.
 type GRPCServerOption func(*grpcServerConfig)
 
 type grpcServerConfig struct {
@@ -32,11 +36,9 @@ func WithGRPCServerOptions(opts ...grpc.ServerOption) GRPCServerOption {
 	}
 }
 
-// StartGRPCServer constructs a gRPC server configured from cfg and the provided
-// options, registers the application's services and reflection, and returns it.
-// The returned server is not yet serving; the caller is responsible for calling
-// Serve on a listener and for stopping it (e.g. via GracefulStop).
-func StartGRPCServer(clientCtx client.Context, app types.Application, cfg config.GRPCConfig, opts ...GRPCServerOption) (*grpc.Server, error) {
+// NewGRPCServer returns a correctly configured and initialized gRPC server.
+// Note, the caller is responsible for starting the server. See StartGRPCServer.
+func NewGRPCServer(clientCtx client.Context, app types.Application, cfg config.GRPCConfig, opts ...GRPCServerOption) (*grpc.Server, error) {
 	maxSendMsgSize := cfg.MaxSendMsgSize
 	if maxSendMsgSize == 0 {
 		maxSendMsgSize = config.DefaultGRPCMaxSendMsgSize
@@ -89,4 +91,42 @@ func StartGRPCServer(clientCtx client.Context, app types.Application, cfg config
 	gogoreflection.Register(grpcSrv)
 
 	return grpcSrv, nil
+}
+
+// StartGRPCServer starts the provided gRPC server on the address specified in cfg.
+//
+// Note, this creates a blocking process if the server is started successfully.
+// Otherwise, an error is returned. The caller is expected to provide a Context
+// that is properly canceled or closed to indicate the server should be stopped.
+func StartGRPCServer(ctx context.Context, logger log.Logger, cfg config.GRPCConfig, grpcSrv *grpc.Server) error {
+	listener, err := net.Listen("tcp", cfg.Address)
+	if err != nil {
+		return fmt.Errorf("failed to listen on address %s: %w", cfg.Address, err)
+	}
+
+	errCh := make(chan error)
+
+	// Start the gRPC in an external goroutine as Serve is blocking and will return
+	// an error upon failure, which we'll send on the error channel that will be
+	// consumed by the for block below.
+	go func() {
+		logger.Info("starting gRPC server...", "address", cfg.Address)
+		errCh <- grpcSrv.Serve(listener)
+	}()
+
+	// Start a blocking select to wait for an indication to stop the server or that
+	// the server failed to start properly.
+	select {
+	case <-ctx.Done():
+		// The calling process canceled or closed the provided context, so we must
+		// gracefully stop the gRPC server.
+		logger.Info("stopping gRPC server...", "address", cfg.Address)
+		grpcSrv.GracefulStop()
+
+		return nil
+
+	case err := <-errCh:
+		logger.Error("failed to start gRPC server", "err", err)
+		return err
+	}
 }

--- a/server/grpc/server.go
+++ b/server/grpc/server.go
@@ -19,15 +19,25 @@ import (
 	_ "github.com/cosmos/cosmos-sdk/types/tx/amino" // Import amino.proto file for reflection
 )
 
-// ExtraServerOptions is appended to the options passed to grpc.NewServer in
-// NewGRPCServer. Applications can populate this slice (for example from an
-// init function) to register additional interceptors or stats handlers
-// without forking this package.
-var ExtraServerOptions []grpc.ServerOption
+// GRPCServerOption configures the gRPC server constructed by StartGRPCServer.
+type GRPCServerOption func(*grpcServerConfig)
 
-// NewGRPCServer returns a correctly configured and initialized gRPC server.
-// Note, the caller is responsible for starting the server. See StartGRPCServer.
-func NewGRPCServer(clientCtx client.Context, app types.Application, cfg config.GRPCConfig) (*grpc.Server, error) {
+type grpcServerConfig struct {
+	grpcOpts []grpc.ServerOption
+}
+
+// WithGRPCServerOptions appends extra grpc.ServerOptions (e.g. interceptors,
+// keepalive policies, custom credentials) to the ones the SDK applies by
+// default. The user-provided options are appended after the defaults, so they
+// can override defaults where grpc-go's last-write-wins semantics allow.
+func WithGRPCServerOptions(opts ...grpc.ServerOption) GRPCServerOption {
+	return func(c *grpcServerConfig) {
+		c.grpcOpts = append(c.grpcOpts, opts...)
+	}
+}
+
+// StartGRPCServer starts a gRPC server on the given address.
+func StartGRPCServer(clientCtx client.Context, app types.Application, cfg config.GRPCConfig, opts ...GRPCServerOption) (*grpc.Server, error) {
 	maxSendMsgSize := cfg.MaxSendMsgSize
 	if maxSendMsgSize == 0 {
 		maxSendMsgSize = config.DefaultGRPCMaxSendMsgSize
@@ -38,12 +48,18 @@ func NewGRPCServer(clientCtx client.Context, app types.Application, cfg config.G
 		maxRecvMsgSize = config.DefaultGRPCMaxRecvMsgSize
 	}
 
+	serverConfig := &grpcServerConfig{}
+	for _, opt := range opts {
+		opt(serverConfig)
+	}
+
 	serverOpts := []grpc.ServerOption{
 		grpc.ForceServerCodec(codec.NewProtoCodec(clientCtx.InterfaceRegistry).GRPCCodec()),
 		grpc.MaxSendMsgSize(maxSendMsgSize),
 		grpc.MaxRecvMsgSize(maxRecvMsgSize),
 	}
-	serverOpts = append(serverOpts, ExtraServerOptions...)
+	serverOpts = append(serverOpts, serverConfig.grpcOpts...)
+
 	grpcSrv := grpc.NewServer(serverOpts...)
 
 	app.RegisterGRPCServer(grpcSrv)

--- a/server/grpc/server.go
+++ b/server/grpc/server.go
@@ -1,13 +1,9 @@
 package grpc
 
 import (
-	"context"
 	"fmt"
-	"net"
 
 	"google.golang.org/grpc"
-
-	"cosmossdk.io/log"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -36,7 +32,10 @@ func WithGRPCServerOptions(opts ...grpc.ServerOption) GRPCServerOption {
 	}
 }
 
-// StartGRPCServer starts a gRPC server on the given address.
+// StartGRPCServer constructs a gRPC server configured from cfg and the provided
+// options, registers the application's services and reflection, and returns it.
+// The returned server is not yet serving; the caller is responsible for calling
+// Serve on a listener and for stopping it (e.g. via GracefulStop).
 func StartGRPCServer(clientCtx client.Context, app types.Application, cfg config.GRPCConfig, opts ...GRPCServerOption) (*grpc.Server, error) {
 	maxSendMsgSize := cfg.MaxSendMsgSize
 	if maxSendMsgSize == 0 {
@@ -90,42 +89,4 @@ func StartGRPCServer(clientCtx client.Context, app types.Application, cfg config
 	gogoreflection.Register(grpcSrv)
 
 	return grpcSrv, nil
-}
-
-// StartGRPCServer starts the provided gRPC server on the address specified in cfg.
-//
-// Note, this creates a blocking process if the server is started successfully.
-// Otherwise, an error is returned. The caller is expected to provide a Context
-// that is properly canceled or closed to indicate the server should be stopped.
-func StartGRPCServer(ctx context.Context, logger log.Logger, cfg config.GRPCConfig, grpcSrv *grpc.Server) error {
-	listener, err := net.Listen("tcp", cfg.Address)
-	if err != nil {
-		return fmt.Errorf("failed to listen on address %s: %w", cfg.Address, err)
-	}
-
-	errCh := make(chan error)
-
-	// Start the gRPC in an external goroutine as Serve is blocking and will return
-	// an error upon failure, which we'll send on the error channel that will be
-	// consumed by the for block below.
-	go func() {
-		logger.Info("starting gRPC server...", "address", cfg.Address)
-		errCh <- grpcSrv.Serve(listener)
-	}()
-
-	// Start a blocking select to wait for an indication to stop the server or that
-	// the server failed to start properly.
-	select {
-	case <-ctx.Done():
-		// The calling process canceled or closed the provided context, so we must
-		// gracefully stop the gRPC server.
-		logger.Info("stopping gRPC server...", "address", cfg.Address)
-		grpcSrv.GracefulStop()
-
-		return nil
-
-	case err := <-errCh:
-		logger.Error("failed to start gRPC server", "err", err)
-		return err
-	}
 }

--- a/server/grpc/server_test.go
+++ b/server/grpc/server_test.go
@@ -13,9 +13,12 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 
+	"cosmossdk.io/log"
+
 	"github.com/cosmos/cosmos-sdk/client"
 	reflectionv1 "github.com/cosmos/cosmos-sdk/client/grpc/reflection"
 	clienttx "github.com/cosmos/cosmos-sdk/client/tx"
+	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/server/config"
 	servergrpc "github.com/cosmos/cosmos-sdk/server/grpc"
 	reflectionv2 "github.com/cosmos/cosmos-sdk/server/grpc/reflection/v2alpha1"
@@ -245,19 +248,29 @@ func (s *IntegrationTestSuite) TestStartGRPCServer_AppliesOptions() {
 	addr := l.Addr().String()
 	l.Close()
 
+	cfg := config.GRPCConfig{Address: addr, Enable: true}
+
 	// Override the default max-receive size with a 1-byte cap. Any real
 	// request will be larger than 1 byte, so if the option flowed through
 	// the call must fail with ResourceExhausted.
-	srv, err := servergrpc.StartGRPCServer(
-		val0.ClientCtx, s.app,
-		config.GRPCConfig{Address: addr, Enable: true},
+	srv, err := servergrpc.NewGRPCServer(
+		val0.ClientCtx, val0.GetApp(), cfg,
 		servergrpc.WithGRPCServerOptions(grpc.MaxRecvMsgSize(1)),
 	)
 	s.Require().NoError(err)
-	defer srv.Stop()
 
-	conn, err := grpc.Dial(addr, grpc.WithInsecure(),
-		grpc.WithDefaultCallOptions(grpc.ForceCodec(codec.NewProtoCodec(s.app.InterfaceRegistry()).GRPCCodec())))
+	ctx, cancel := context.WithCancel(context.Background())
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- servergrpc.StartGRPCServer(ctx, log.NewNopLogger(), cfg, srv)
+	}()
+	defer func() {
+		cancel()
+		<-serveErr
+	}()
+
+	conn, err := grpc.Dial(addr, grpc.WithInsecure(), //nolint:staticcheck // ignore SA1019, deprecated test helper
+		grpc.WithDefaultCallOptions(grpc.ForceCodec(codec.NewProtoCodec(s.cfg.InterfaceRegistry).GRPCCodec())))
 	s.Require().NoError(err)
 	defer conn.Close()
 

--- a/server/grpc/server_test.go
+++ b/server/grpc/server_test.go
@@ -3,6 +3,7 @@ package grpc_test
 import (
 	"context"
 	"fmt"
+	"net"
 	"testing"
 	"time"
 
@@ -15,7 +16,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	reflectionv1 "github.com/cosmos/cosmos-sdk/client/grpc/reflection"
 	clienttx "github.com/cosmos/cosmos-sdk/client/tx"
-	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/server/config"
+	servergrpc "github.com/cosmos/cosmos-sdk/server/grpc"
 	reflectionv2 "github.com/cosmos/cosmos-sdk/server/grpc/reflection/v2alpha1"
 	"github.com/cosmos/cosmos-sdk/testutil/network"
 	"github.com/cosmos/cosmos-sdk/testutil/testdata"
@@ -233,6 +235,35 @@ func (s *IntegrationTestSuite) TestGRPCUnpacker() {
 	addr, err := validator.Validator.GetConsAddr()
 	require.NotNil(s.T(), addr)
 	require.NoError(s.T(), err)
+}
+
+func (s *IntegrationTestSuite) TestStartGRPCServer_AppliesOptions() {
+	val0 := s.network.Validators[0]
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	s.Require().NoError(err)
+	addr := l.Addr().String()
+	l.Close()
+
+	// Override the default max-receive size with a 1-byte cap. Any real
+	// request will be larger than 1 byte, so if the option flowed through
+	// the call must fail with ResourceExhausted.
+	srv, err := servergrpc.StartGRPCServer(
+		val0.ClientCtx, s.app,
+		config.GRPCConfig{Address: addr, Enable: true},
+		servergrpc.WithGRPCServerOptions(grpc.MaxRecvMsgSize(1)),
+	)
+	s.Require().NoError(err)
+	defer srv.Stop()
+
+	conn, err := grpc.Dial(addr, grpc.WithInsecure(),
+		grpc.WithDefaultCallOptions(grpc.ForceCodec(codec.NewProtoCodec(s.app.InterfaceRegistry()).GRPCCodec())))
+	s.Require().NoError(err)
+	defer conn.Close()
+
+	_, err = testdata.NewQueryClient(conn).Echo(context.Background(), &testdata.EchoRequest{Message: "hello"})
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "larger than max")
 }
 
 // mkTxBuilder creates a TxBuilder containing a signed tx from validator 0.

--- a/testutil/network/network.go
+++ b/testutil/network/network.go
@@ -311,6 +311,11 @@ func (v Validator) GetAppConfig() *srvconfig.Config {
 	return v.AppConfig
 }
 
+// GetApp returns the underlying ABCI application instance for the validator.
+func (v Validator) GetApp() servertypes.Application {
+	return v.app
+}
+
 // CLILogger wraps a cobra.Command and provides command logging methods.
 type CLILogger struct {
 	cmd *cobra.Command


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Adds opts for gRPC server initialisation in order for app to pass interceptors. 