### PR TITLE
feat: add ethereum tx sign mode support

### DIFF
--- a/api/cosmos/tx/signing/v1beta1/signing.pulsar.go
+++ b/api/cosmos/tx/signing/v1beta1/signing.pulsar.go
@@ -2753,18 +2753,27 @@ const (
 	// secp256k1 public key from the signature. Apps must register a sign mode
 	// handler that implements the app-specific typed-data schema.
 	SignMode_SIGN_MODE_EIP_712 SignMode = 712
+	// SIGN_MODE_ETHEREUM_TX specifies the sign mode for Ethereum transaction
+	// envelope signing.
+	//
+	// Ethereum transaction signatures are over the Ethereum transaction signing
+	// hash and may recover the secp256k1 public key from the signature. Apps must
+	// register a sign mode handler that implements app-specific envelope
+	// translation and authorization checks.
+	SignMode_SIGN_MODE_ETHEREUM_TX SignMode = 1559
 )
 
 // Enum value maps for SignMode.
 var (
 	SignMode_name = map[int32]string{
-		0:   "SIGN_MODE_UNSPECIFIED",
-		1:   "SIGN_MODE_DIRECT",
-		2:   "SIGN_MODE_TEXTUAL",
-		3:   "SIGN_MODE_DIRECT_AUX",
-		127: "SIGN_MODE_LEGACY_AMINO_JSON",
-		191: "SIGN_MODE_EIP_191",
-		712: "SIGN_MODE_EIP_712",
+		0:    "SIGN_MODE_UNSPECIFIED",
+		1:    "SIGN_MODE_DIRECT",
+		2:    "SIGN_MODE_TEXTUAL",
+		3:    "SIGN_MODE_DIRECT_AUX",
+		127:  "SIGN_MODE_LEGACY_AMINO_JSON",
+		191:  "SIGN_MODE_EIP_191",
+		712:  "SIGN_MODE_EIP_712",
+		1559: "SIGN_MODE_ETHEREUM_TX",
 	}
 	SignMode_value = map[string]int32{
 		"SIGN_MODE_UNSPECIFIED":       0,
@@ -2774,6 +2783,7 @@ var (
 		"SIGN_MODE_LEGACY_AMINO_JSON": 127,
 		"SIGN_MODE_EIP_191":           191,
 		"SIGN_MODE_EIP_712":           712,
+		"SIGN_MODE_ETHEREUM_TX":       1559,
 	}
 )
 

--- a/client/flags/flags.go
+++ b/client/flags/flags.go
@@ -40,6 +40,8 @@ const (
 	SignModeEIP191 = "eip-191"
 	// SignModeEIP712 is the value of the --sign-mode flag for SIGN_MODE_EIP_712
 	SignModeEIP712 = "eip-712"
+	// SignModeEthereumTx is the value of the --sign-mode flag for SIGN_MODE_ETHEREUM_TX
+	SignModeEthereumTx = "ethereum-tx"
 )
 
 // List of CLI flags
@@ -136,7 +138,7 @@ func AddTxFlagsToCmd(cmd *cobra.Command) {
 	f.Bool(FlagGenerateOnly, false, "Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase only accessed when providing a key name)")
 	f.Bool(FlagOffline, false, "Offline mode (does not allow any online functionality)")
 	f.BoolP(FlagSkipConfirmation, "y", false, "Skip tx broadcasting prompt confirmation")
-	f.String(FlagSignMode, "", "Choose sign mode (direct|amino-json|direct-aux|textual), this is an advanced feature")
+	f.String(FlagSignMode, "", "Choose sign mode (direct|amino-json|direct-aux|textual|eip-712|ethereum-tx), this is an advanced feature")
 	f.Uint64(FlagTimeoutHeight, 0, "Set a block timeout height to prevent the tx from being committed past a certain height")
 	f.String(FlagFeePayer, "", "Fee payer pays fees for the transaction instead of deducting from the signer")
 	f.String(FlagFeeGranter, "", "Fee granter grants fees for the transaction")

--- a/client/tx/factory.go
+++ b/client/tx/factory.go
@@ -64,6 +64,8 @@ func NewFactoryCLI(clientCtx client.Context, flagSet *pflag.FlagSet) (Factory, e
 		signMode = signing.SignMode_SIGN_MODE_EIP_191
 	case flags.SignModeEIP712:
 		signMode = signing.SignMode_SIGN_MODE_EIP_712
+	case flags.SignModeEthereumTx:
+		signMode = signing.SignMode_SIGN_MODE_ETHEREUM_TX
 	}
 
 	var accNum, accSeq uint64

--- a/go.mod
+++ b/go.mod
@@ -208,7 +208,7 @@ replace (
 	cosmossdk.io/api => ./api
 	cosmossdk.io/log => ./log
 	cosmossdk.io/store => ./store
-	cosmossdk.io/x/tx => ./x/tx
+	cosmossdk.io/x/tx => github.com/celestiaorg/cosmos-sdk/x/tx v0.13.10-0.20260520081233-a400504a2d08
 	// use cosmos fork of keyring
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.2.0
 	github.com/cometbft/cometbft => github.com/celestiaorg/celestia-core v0.39.25

--- a/go.sum
+++ b/go.sum
@@ -112,6 +112,8 @@ github.com/bytedance/sonic v1.9.1/go.mod h1:i736AoUSYt75HyZLoJW9ERYxcy6eaN6h4BZX
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/celestiaorg/celestia-core v0.39.25 h1:aA8rx5LoTrQd85GVw77tfOSo0rmRY3LAioXu8sVYhK4=
 github.com/celestiaorg/celestia-core v0.39.25/go.mod h1:Lx/ykikvZF3ZMHUDEPtAXYP/6a6y8n9Eh0YIVpO0RyQ=
+github.com/celestiaorg/cosmos-sdk/x/tx v0.13.10-0.20260520081233-a400504a2d08 h1:Qw7qCty/arL717cEOJSO4s/XkeJ6RPrbN5+8jgtdaTY=
+github.com/celestiaorg/cosmos-sdk/x/tx v0.13.10-0.20260520081233-a400504a2d08/go.mod h1:V6DImnwJMTq5qFjeGWpXNiT/fjgE4HtmclRmTqRVM3w=
 github.com/celestiaorg/go-square/v3 v3.0.2 h1:eSQOgNII8inK9IhiBZ+6GADQeWbRq4HYY72BOgcduA4=
 github.com/celestiaorg/go-square/v3 v3.0.2/go.mod h1:oFReMLsSDMRs82ICFEeFQFCqNvwdsbIM1BzCcb0f7dM=
 github.com/celestiaorg/nmt v0.24.2 h1:LlpJSPOd6/Lw1Ig6HUhZuqiINHLka/ZSRTBzlNJpchg=

--- a/proto/cosmos/tx/signing/v1beta1/signing.proto
+++ b/proto/cosmos/tx/signing/v1beta1/signing.proto
@@ -59,6 +59,15 @@ enum SignMode {
   // secp256k1 public key from the signature. Apps must register a sign mode
   // handler that implements the app-specific typed-data schema.
   SIGN_MODE_EIP_712 = 712;
+
+  // SIGN_MODE_ETHEREUM_TX specifies the sign mode for Ethereum transaction
+  // envelope signing.
+  //
+  // Ethereum transaction signatures are over the Ethereum transaction signing
+  // hash and may recover the secp256k1 public key from the signature. Apps must
+  // register a sign mode handler that implements app-specific envelope
+  // translation and authorization checks.
+  SIGN_MODE_ETHEREUM_TX = 1559;
 }
 
 // SignatureDescriptors wraps multiple SignatureDescriptor's.

--- a/simapp/go.mod
+++ b/simapp/go.mod
@@ -236,6 +236,7 @@ replace (
 	cosmossdk.io/api => ../api
 	cosmossdk.io/log => ../log
 	cosmossdk.io/store => ../store
+	cosmossdk.io/x/tx => github.com/celestiaorg/cosmos-sdk/x/tx v0.13.10-0.20260520081233-a400504a2d08
 	// use cosmos fork of keyring
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.2.0
 	github.com/cometbft/cometbft => github.com/celestiaorg/celestia-core v0.39.25

--- a/simapp/go.sum
+++ b/simapp/go.sum
@@ -312,6 +312,8 @@ github.com/bytedance/sonic v1.9.1/go.mod h1:i736AoUSYt75HyZLoJW9ERYxcy6eaN6h4BZX
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/celestiaorg/celestia-core v0.39.25 h1:aA8rx5LoTrQd85GVw77tfOSo0rmRY3LAioXu8sVYhK4=
 github.com/celestiaorg/celestia-core v0.39.25/go.mod h1:Lx/ykikvZF3ZMHUDEPtAXYP/6a6y8n9Eh0YIVpO0RyQ=
+github.com/celestiaorg/cosmos-sdk/x/tx v0.13.10-0.20260520081233-a400504a2d08 h1:Qw7qCty/arL717cEOJSO4s/XkeJ6RPrbN5+8jgtdaTY=
+github.com/celestiaorg/cosmos-sdk/x/tx v0.13.10-0.20260520081233-a400504a2d08/go.mod h1:V6DImnwJMTq5qFjeGWpXNiT/fjgE4HtmclRmTqRVM3w=
 github.com/celestiaorg/go-square/v3 v3.0.2 h1:eSQOgNII8inK9IhiBZ+6GADQeWbRq4HYY72BOgcduA4=
 github.com/celestiaorg/go-square/v3 v3.0.2/go.mod h1:oFReMLsSDMRs82ICFEeFQFCqNvwdsbIM1BzCcb0f7dM=
 github.com/celestiaorg/nmt v0.24.2 h1:LlpJSPOd6/Lw1Ig6HUhZuqiINHLka/ZSRTBzlNJpchg=

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -236,6 +236,7 @@ replace (
 	// We always want to test against the latest version of the simapp.
 	cosmossdk.io/simapp => ../simapp
 	cosmossdk.io/store => ../store
+	cosmossdk.io/x/tx => github.com/celestiaorg/cosmos-sdk/x/tx v0.13.10-0.20260520081233-a400504a2d08
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.2.0
 	github.com/cometbft/cometbft => github.com/celestiaorg/celestia-core v0.39.25
 	// We always want to test against the latest version of the SDK.

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -202,8 +202,6 @@ cosmossdk.io/x/feegrant v0.1.1 h1:EKFWOeo/pup0yF0svDisWWKAA9Zags6Zd0P3nRvVvw8=
 cosmossdk.io/x/feegrant v0.1.1/go.mod h1:2GjVVxX6G2fta8LWj7pC/ytHjryA6MHAJroBWHFNiEQ=
 cosmossdk.io/x/nft v0.1.1 h1:pslAVS8P5NkW080+LWOamInjDcq+v2GSCo+BjN9sxZ8=
 cosmossdk.io/x/nft v0.1.1/go.mod h1:Kac6F6y2gsKvoxU+fy8uvxRTi4BIhLOor2zgCNQwVgY=
-cosmossdk.io/x/tx v0.13.7 h1:8WSk6B/OHJLYjiZeMKhq7DK7lHDMyK0UfDbBMxVmeOI=
-cosmossdk.io/x/tx v0.13.7/go.mod h1:V6DImnwJMTq5qFjeGWpXNiT/fjgE4HtmclRmTqRVM3w=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 filippo.io/edwards25519 v1.0.0 h1:0wAIcmJUqRdI8IJ/3eGi5/HwXZWPujYXXlkrQogz0Ek=
 filippo.io/edwards25519 v1.0.0/go.mod h1:N1IkdkCkiLB6tki+MYJoSx2JTY9NUlxZE7eHn5EwJns=
@@ -310,6 +308,8 @@ github.com/bytedance/sonic v1.9.1/go.mod h1:i736AoUSYt75HyZLoJW9ERYxcy6eaN6h4BZX
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/celestiaorg/celestia-core v0.39.25 h1:aA8rx5LoTrQd85GVw77tfOSo0rmRY3LAioXu8sVYhK4=
 github.com/celestiaorg/celestia-core v0.39.25/go.mod h1:Lx/ykikvZF3ZMHUDEPtAXYP/6a6y8n9Eh0YIVpO0RyQ=
+github.com/celestiaorg/cosmos-sdk/x/tx v0.13.10-0.20260520081233-a400504a2d08 h1:Qw7qCty/arL717cEOJSO4s/XkeJ6RPrbN5+8jgtdaTY=
+github.com/celestiaorg/cosmos-sdk/x/tx v0.13.10-0.20260520081233-a400504a2d08/go.mod h1:V6DImnwJMTq5qFjeGWpXNiT/fjgE4HtmclRmTqRVM3w=
 github.com/celestiaorg/go-square/v3 v3.0.2 h1:eSQOgNII8inK9IhiBZ+6GADQeWbRq4HYY72BOgcduA4=
 github.com/celestiaorg/go-square/v3 v3.0.2/go.mod h1:oFReMLsSDMRs82ICFEeFQFCqNvwdsbIM1BzCcb0f7dM=
 github.com/celestiaorg/nmt v0.24.2 h1:LlpJSPOd6/Lw1Ig6HUhZuqiINHLka/ZSRTBzlNJpchg=

--- a/types/tx/signing/signing.pb.go
+++ b/types/tx/signing/signing.pb.go
@@ -73,16 +73,25 @@ const (
 	// secp256k1 public key from the signature. Apps must register a sign mode
 	// handler that implements the app-specific typed-data schema.
 	SignMode_SIGN_MODE_EIP_712 SignMode = 712
+	// SIGN_MODE_ETHEREUM_TX specifies the sign mode for Ethereum transaction
+	// envelope signing.
+	//
+	// Ethereum transaction signatures are over the Ethereum transaction signing
+	// hash and may recover the secp256k1 public key from the signature. Apps must
+	// register a sign mode handler that implements app-specific envelope
+	// translation and authorization checks.
+	SignMode_SIGN_MODE_ETHEREUM_TX SignMode = 1559
 )
 
 var SignMode_name = map[int32]string{
-	0:   "SIGN_MODE_UNSPECIFIED",
-	1:   "SIGN_MODE_DIRECT",
-	2:   "SIGN_MODE_TEXTUAL",
-	3:   "SIGN_MODE_DIRECT_AUX",
-	127: "SIGN_MODE_LEGACY_AMINO_JSON",
-	191: "SIGN_MODE_EIP_191",
-	712: "SIGN_MODE_EIP_712",
+	0:    "SIGN_MODE_UNSPECIFIED",
+	1:    "SIGN_MODE_DIRECT",
+	2:    "SIGN_MODE_TEXTUAL",
+	3:    "SIGN_MODE_DIRECT_AUX",
+	127:  "SIGN_MODE_LEGACY_AMINO_JSON",
+	191:  "SIGN_MODE_EIP_191",
+	712:  "SIGN_MODE_EIP_712",
+	1559: "SIGN_MODE_ETHEREUM_TX",
 }
 
 var SignMode_value = map[string]int32{
@@ -93,6 +102,7 @@ var SignMode_value = map[string]int32{
 	"SIGN_MODE_LEGACY_AMINO_JSON": 127,
 	"SIGN_MODE_EIP_191":           191,
 	"SIGN_MODE_EIP_712":           712,
+	"SIGN_MODE_ETHEREUM_TX":       1559,
 }
 
 func (x SignMode) String() string {

--- a/x/auth/signing/verify.go
+++ b/x/auth/signing/verify.go
@@ -44,6 +44,8 @@ func APISignModeToInternal(mode signingv1beta1.SignMode) (signing.SignMode, erro
 		return signing.SignMode_SIGN_MODE_DIRECT_AUX, nil
 	case signingv1beta1.SignMode_SIGN_MODE_EIP_712:
 		return signing.SignMode_SIGN_MODE_EIP_712, nil
+	case signingv1beta1.SignMode_SIGN_MODE_ETHEREUM_TX:
+		return signing.SignMode_SIGN_MODE_ETHEREUM_TX, nil
 	default:
 		return signing.SignMode_SIGN_MODE_UNSPECIFIED, fmt.Errorf("unsupported sign mode %s", mode)
 	}
@@ -62,6 +64,8 @@ func internalSignModeToAPI(mode signing.SignMode) (signingv1beta1.SignMode, erro
 		return signingv1beta1.SignMode_SIGN_MODE_DIRECT_AUX, nil
 	case signing.SignMode_SIGN_MODE_EIP_712:
 		return signingv1beta1.SignMode_SIGN_MODE_EIP_712, nil
+	case signing.SignMode_SIGN_MODE_ETHEREUM_TX:
+		return signingv1beta1.SignMode_SIGN_MODE_ETHEREUM_TX, nil
 	default:
 		return signingv1beta1.SignMode_SIGN_MODE_UNSPECIFIED, fmt.Errorf("unsupported sign mode %s", mode)
 	}

--- a/x/auth/signing/verify_test.go
+++ b/x/auth/signing/verify_test.go
@@ -17,3 +17,13 @@ func TestEIP712SignModeConversion(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, signingv1beta1.SignMode_SIGN_MODE_EIP_712, api)
 }
+
+func TestEthereumTxSignModeConversion(t *testing.T) {
+	internal, err := APISignModeToInternal(signingv1beta1.SignMode_SIGN_MODE_ETHEREUM_TX)
+	require.NoError(t, err)
+	require.Equal(t, signing.SignMode_SIGN_MODE_ETHEREUM_TX, internal)
+
+	api, err := internalSignModeToAPI(signing.SignMode_SIGN_MODE_ETHEREUM_TX)
+	require.NoError(t, err)
+	require.Equal(t, signingv1beta1.SignMode_SIGN_MODE_ETHEREUM_TX, api)
+}

--- a/x/auth/tx/adapter.go
+++ b/x/auth/tx/adapter.go
@@ -70,7 +70,7 @@ func (w *wrapper) GetSigningTxData() txsigning.TxData {
 				TypeUrl: signerInfo.PublicKey.TypeUrl,
 				Value:   signerInfo.PublicKey.Value,
 			}
-		} else if !isEIP712SignerInfo(signerInfo) {
+		} else if !isEIP712SignerInfo(signerInfo) && !isEthereumTxSignerInfo(signerInfo) {
 			panic("signerInfo.PublicKey cannot be nil")
 		}
 		txSignerInfos[i] = txSignerInfo
@@ -107,6 +107,13 @@ func isEIP712SignerInfo(signerInfo *tx.SignerInfo) bool {
 		return false
 	}
 	return signerInfo.ModeInfo.GetSingle().Mode == signingtypes.SignMode_SIGN_MODE_EIP_712
+}
+
+func isEthereumTxSignerInfo(signerInfo *tx.SignerInfo) bool {
+	if signerInfo == nil || signerInfo.ModeInfo == nil || signerInfo.ModeInfo.GetSingle() == nil {
+		return false
+	}
+	return signerInfo.ModeInfo.GetSingle().Mode == signingtypes.SignMode_SIGN_MODE_ETHEREUM_TX
 }
 
 func adaptModeInfo(legacy *tx.ModeInfo, res *txv1beta1.ModeInfo) {


### PR DESCRIPTION
## Description

This PR follows on from #737 and adds an additional sign mode enum `SIGN_MODE_ETHEREUM_TX`. 

`SIGN_MODE_ETHEREUM_TX` names the authorization format broadly as a signed Ethereum transaction envelope rather than coupling consensus semantics to EIP-1559 specifically; the initial implementation intentionally supports only type-2 EIP-1559 value transfers, but the sign mode can remain valid if later slices add other Ethereum envelope types.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] added `!` to the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] run `make lint` and `make test`
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
