### PR TITLE
fix: data race between workingHash (FinalizeBlock) and Simulate

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -1008,6 +1008,16 @@ func (app *BaseApp) Commit() (*abci.ResponseCommit, error) {
 // state transitions will be flushed to disk and as a result, but we already have
 // an application Merkle root.
 func (app *BaseApp) workingHash() []byte {
+	// Hold the write lock across the writes into the root MultiStore. The write
+	// of the FinalizeBlock state mutates the underlying IAVL tree
+	// (MutableTree.Set), and cms.WorkingHash() reads/computes over that same
+	// tree. Concurrent Simulate() calls (e.g. from the gas estimation gRPC
+	// service) hold checkStateMu.RLock while reading the IAVL tree throughout
+	// runTx, so this write lock prevents a data race with block finalization.
+	// This mirrors the lock Commit() holds around cms.Commit().
+	app.checkStateMu.Lock()
+	defer app.checkStateMu.Unlock()
+
 	// Write the FinalizeBlock state into branched storage and commit the MultiStore.
 	// The write to the FinalizeBlock state writes all state transitions to the root
 	// MultiStore (app.cms) so when Commit() is called it persists those values.

--- a/baseapp/baseapp_test.go
+++ b/baseapp/baseapp_test.go
@@ -928,6 +928,99 @@ func TestCommitSimulateRace(t *testing.T) {
 	wg.Wait()
 }
 
+// TestFinalizeBlockSimulateRace reproduces a data race between FinalizeBlock and
+// Simulate. FinalizeBlock calls workingHash() which writes the block's state
+// transitions into the root IAVL tree via finalizeBlockState.ms.Write()
+// (MutableTree.Set). Simulate concurrently reads the same IAVL tree during
+// message execution (MutableTree.Get). Unlike TestCommitSimulateRace, the
+// simulated tx routes to a message handler that actually reads store state, so
+// the read falls through to the parent IAVL tree on a cache miss. This mirrors
+// the production race observed in celestia-app where the gas estimation gRPC
+// service calls Simulate concurrently with block finalization.
+// See https://github.com/celestiaorg/cosmos-sdk/issues/739
+func TestFinalizeBlockSimulateRace(t *testing.T) {
+	// The writer mutates store state via a PreBlocker rather than via a tx so
+	// that FinalizeBlock does not decode txs / call GetSigners. Combined with a
+	// single reader goroutine (whose GetSigners calls are therefore serial),
+	// this isolates the Simulate-vs-FinalizeBlock IAVL race from unrelated
+	// concurrency in the shared tx decoder / signing context.
+	preBlocker := func(ctx sdk.Context, req *abci.RequestFinalizeBlock) (*sdk.ResponsePreBlock, error) {
+		store := ctx.KVStore(capKey2)
+		store.Set([]byte(fmt.Sprintf("key-%d", req.Height)), bytes.Repeat([]byte("a"), 64))
+		return &sdk.ResponsePreBlock{}, nil
+	}
+	suite := NewBaseAppSuite(t, func(app *baseapp.BaseApp) { app.SetPreBlocker(preBlocker) })
+	baseapptestutil.RegisterKeyValueServer(suite.baseApp.MsgServiceRouter(), ReadWriteKeyValueImpl{})
+
+	_, err := suite.baseApp.InitChain(&abci.RequestInitChain{
+		ConsensusParams: &cmtproto.ConsensusParams{},
+	})
+	require.NoError(t, err)
+
+	// Commit an initial block so the IAVL tree has committed nodes to traverse.
+	_, err = suite.baseApp.FinalizeBlock(&abci.RequestFinalizeBlock{Height: 1})
+	require.NoError(t, err)
+	_, err = suite.baseApp.Commit()
+	require.NoError(t, err)
+
+	// Build a tx whose handler reads store state during simulation.
+	_, _, addr := testdata.KeyTestPubAddr()
+	builder := suite.txConfig.NewTxBuilder()
+	require.NoError(t, builder.SetMsgs(&baseapptestutil.MsgKeyValue{
+		Key:    []byte("key-1"),
+		Value:  bytes.Repeat([]byte("b"), 64),
+		Signer: addr.String(),
+	}))
+	setTxSignature(t, builder, 0)
+	simTx, err := suite.txConfig.TxEncoder()(builder.GetTx())
+	require.NoError(t, err)
+
+	// Warm up the simulate path once, single-threaded, so the lazy
+	// signing-context and proto-reflection caches are populated before the
+	// reader goroutine starts. This keeps the test focused on the IAVL data
+	// race rather than unrelated cold-start races in tx decoding.
+	_, _, _ = suite.baseApp.Simulate(simTx)
+
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Writer goroutine: repeatedly finalize + commit blocks. The PreBlocker
+	// writes store state, so FinalizeBlock's workingHash() flushes those writes
+	// into the root IAVL tree (MutableTree.Set).
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for height := int64(2); ; height++ {
+			select {
+			case <-done:
+				return
+			default:
+			}
+			_, _ = suite.baseApp.FinalizeBlock(&abci.RequestFinalizeBlock{Height: height})
+			_, _ = suite.baseApp.Commit()
+		}
+	}()
+
+	// Reader goroutine: repeatedly Simulate a tx whose handler reads store
+	// state, reaching the parent IAVL tree (MutableTree.Get) on a cache miss.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-done:
+				return
+			default:
+			}
+			_, _, _ = suite.baseApp.Simulate(simTx)
+		}
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	close(done)
+	wg.Wait()
+}
+
 func TestSetMinGasPrices(t *testing.T) {
 	minGasPrices := sdk.DecCoins{sdk.NewInt64DecCoin("stake", 5000)}
 	suite := NewBaseAppSuite(t, baseapp.SetMinGasPrices(minGasPrices.String()))

--- a/baseapp/utils_test.go
+++ b/baseapp/utils_test.go
@@ -116,6 +116,22 @@ func (m MsgKeyValueImpl) Set(ctx context.Context, msg *baseapptestutil.MsgKeyVal
 	return &baseapptestutil.MsgCreateKeyValueResponse{}, nil
 }
 
+// ReadWriteKeyValueImpl is a KeyValue message handler that both reads and then
+// writes store state. The read forces a lookup that falls through to the parent
+// IAVL tree on a cache miss, which is required to reproduce the data race
+// between Simulate (read) and FinalizeBlock's workingHash (write). See
+// TestFinalizeBlockSimulateRace.
+type ReadWriteKeyValueImpl struct{}
+
+func (m ReadWriteKeyValueImpl) Set(ctx context.Context, msg *baseapptestutil.MsgKeyValue) (*baseapptestutil.MsgCreateKeyValueResponse, error) {
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+	store := sdkCtx.KVStore(capKey2)
+	// Read first so simulated txs traverse the parent IAVL tree on a cache miss.
+	_ = store.Get(msg.Key)
+	store.Set(msg.Key, msg.Value)
+	return &baseapptestutil.MsgCreateKeyValueResponse{}, nil
+}
+
 type CounterServerImplGasMeterOnly struct {
 	gas uint64
 }


### PR DESCRIPTION
## Problem

celestia-app's nightly `test-race` job fails intermittently with a `DATA RACE` in `TestTxsimCommandFlags` ([failing run](https://github.com/celestiaorg/celestia-app/actions/runs/26992967367)):

```
Write: FinalizeBlock -> workingHash -> finalizeBlockState.ms.Write -> iavl.MutableTree.Set
Read:  Simulate -> runTx -> ante DeductFees -> bank.GetBalance -> iavl.MutableTree.Get
```

`workingHash()` (called from `FinalizeBlock`) flushes `finalizeBlockState` into the root multistore, mutating the live IAVL `MutableTree` — **without holding `checkStateMu`**. A concurrent `Simulate()` (celestia-app's gas estimation gRPC service calls it on a query goroutine) holds `checkStateMu.RLock` and reads the same `MutableTree` throughout `runTx`, so the two race.

#726 added `checkStateMu` so `Simulate()` (read lock) is mutually exclusive with `Commit()`/`SaveVersion()` (write lock), but it missed the `FinalizeBlock -> workingHash` write path, which also mutates the IAVL tree.

## Fix

Hold `checkStateMu.Lock()` in `workingHash()` around the writes into the root multistore, mirroring the lock `Commit()` already holds around `cms.Commit()`. This makes block finalization mutually exclusive with concurrent `Simulate()` reads, while concurrent `Simulate()` calls still proceed under the read lock.

## Test

`TestFinalizeBlockSimulateRace` routes a simulated tx through a message handler that reads store state (falling through to the parent IAVL tree on a cache miss) concurrently with a writer that finalizes/commits blocks. The writer mutates state via a `PreBlocker` (no tx → no `GetSigners`) and a single reader is used, so the test isolates the `Simulate`-vs-`FinalizeBlock` IAVL race rather than unrelated tx-decoder concurrency.

- Before the fix: reliably reports the `workingHash` vs `Simulate` `MutableTree` race under `-race`.
- After the fix: passes (`-count=5`, plus the full `./baseapp/...` `-race` suite, green).

## Follow-up

A `go.mod` bump in celestia-app is required once this is released, to close the nightly `test-race` failure.

Closes https://github.com/celestiaorg/cosmos-sdk/issues/739
Closes PROTOCO-1889