### PR TITLE
fix: synchronise checkTx

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -353,6 +353,9 @@ func (app *BaseApp) ApplySnapshotChunk(req *abci.RequestApplySnapshotChunk) (*ab
 // will contain relevant error information. Regardless of tx execution outcome,
 // the ResponseCheckTx will contain relevant gas execution context.
 func (app *BaseApp) CheckTx(req *abci.RequestCheckTx) (*abci.ResponseCheckTx, error) {
+	app.checkStateMu.Lock()
+	defer app.checkStateMu.Unlock()
+
 	var mode execMode
 
 	switch {

--- a/baseapp/baseapp_test.go
+++ b/baseapp/baseapp_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"math/rand"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -34,6 +35,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/testutil"
 	"github.com/cosmos/cosmos-sdk/testutil/testdata"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	signingtypes "github.com/cosmos/cosmos-sdk/types/tx/signing"
 	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
 )
 
@@ -1013,6 +1015,106 @@ func TestFinalizeBlockSimulateRace(t *testing.T) {
 			default:
 			}
 			_, _, _ = suite.baseApp.Simulate(simTx)
+		}
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	close(done)
+	wg.Wait()
+}
+
+// TestFinalizeBlockCheckTxRace reproduces the same root-store race as
+// TestFinalizeBlockSimulateRace, but through CheckTx. CheckTx only executes the
+// AnteHandler, so the test AnteHandler performs the store read/write that a
+// message handler performs in the Simulate test.
+func TestFinalizeBlockCheckTxRace(t *testing.T) {
+	preBlocker := func(ctx sdk.Context, req *abci.RequestFinalizeBlock) (*sdk.ResponsePreBlock, error) {
+		store := ctx.KVStore(capKey2)
+		store.Set([]byte(fmt.Sprintf("block-key-%d", req.Height)), bytes.Repeat([]byte("a"), 64))
+		return &sdk.ResponsePreBlock{}, nil
+	}
+	anteHandler := func(ctx sdk.Context, tx sdk.Tx, simulate bool) (sdk.Context, error) {
+		counter, _ := parseTxMemo(t, tx)
+		store := ctx.KVStore(capKey2)
+		key := []byte(fmt.Sprintf("checktx-key-%d", counter))
+		// Read a unique key first so each CheckTx misses through to the parent
+		// store instead of only exercising checkState's local cache.
+		_ = store.Get(key)
+		store.Set(key, bytes.Repeat([]byte("b"), 64))
+		return ctx.WithPriority(testTxPriority), nil
+	}
+	suite := NewBaseAppSuite(t, func(app *baseapp.BaseApp) {
+		app.SetPreBlocker(preBlocker)
+		app.SetAnteHandler(anteHandler)
+	})
+
+	_, err := suite.baseApp.InitChain(&abci.RequestInitChain{
+		ConsensusParams: &cmtproto.ConsensusParams{},
+	})
+	require.NoError(t, err)
+
+	// Commit an initial block so the IAVL tree has committed nodes to traverse.
+	_, err = suite.baseApp.FinalizeBlock(&abci.RequestFinalizeBlock{Height: 1})
+	require.NoError(t, err)
+	_, err = suite.baseApp.Commit()
+	require.NoError(t, err)
+
+	privKey := secp256k1.GenPrivKeyFromSecret([]byte("test"))
+	pubKey := privKey.PubKey()
+	makeCheckTx := func(counter int64) ([]byte, error) {
+		builder := suite.txConfig.NewTxBuilder()
+		builder.SetMemo("counter=" + strconv.FormatInt(counter, 10) + "&failOnAnte=false")
+		err := builder.SetSignatures(
+			signingtypes.SignatureV2{
+				PubKey:   pubKey,
+				Sequence: uint64(counter),
+				Data:     &signingtypes.SingleSignatureData{},
+			},
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		return suite.txConfig.TxEncoder()(builder.GetTx())
+	}
+
+	// Warm up tx decoding and signing-context caches outside the concurrent
+	// section so the test stays focused on CheckTx vs FinalizeBlock.
+	warmupTx, err := makeCheckTx(0)
+	require.NoError(t, err)
+	_, _ = suite.baseApp.CheckTx(&abci.RequestCheckTx{Tx: warmupTx})
+
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for height := int64(2); ; height++ {
+			select {
+			case <-done:
+				return
+			default:
+			}
+			_, _ = suite.baseApp.FinalizeBlock(&abci.RequestFinalizeBlock{Height: height})
+			_, _ = suite.baseApp.Commit()
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for counter := int64(1); ; counter++ {
+			select {
+			case <-done:
+				return
+			default:
+			}
+			tx, err := makeCheckTx(counter)
+			if err != nil {
+				continue
+			}
+			_, _ = suite.baseApp.CheckTx(&abci.RequestCheckTx{Tx: tx})
 		}
 	}()
 

--- a/store/cache/cache.go
+++ b/store/cache/cache.go
@@ -2,7 +2,6 @@ package cache
 
 import (
 	"fmt"
-	"time"
 
 	lru "github.com/hashicorp/golang-lru"
 
@@ -95,9 +94,6 @@ func (ckv *CommitKVStoreCache) CacheWrap() types.CacheWrap {
 	return cachekv.NewStore(ckv)
 }
 
-var start2 = time.Now()
-var hh2 = true
-
 // Get retrieves a value by key. It will first look in the write-through cache.
 // If the value doesn't exist in the write-through cache, the query is delegated
 // to the underlying CommitKVStore.
@@ -113,13 +109,6 @@ func (ckv *CommitKVStoreCache) Get(key []byte) []byte {
 
 	// cache miss; write to cache
 	value := ckv.CommitKVStore.Get(key)
-	if time.Since(start2) > time.Minute {
-		if hh2 {
-			fmt.Println("------------------> starting throttling in Get")
-			hh2 = false
-		}
-		time.Sleep(800 * time.Millisecond)
-	}
 	ckv.cache.Add(keyStr, value)
 
 	return value
@@ -135,19 +124,9 @@ func (ckv *CommitKVStoreCache) Set(key, value []byte) {
 	ckv.CommitKVStore.Set(key, value)
 }
 
-var start = time.Now()
-var hh = true
-
 // Delete removes a key/value pair from both the write-through cache and the
 // underlying CommitKVStore.
 func (ckv *CommitKVStoreCache) Delete(key []byte) {
 	ckv.cache.Remove(string(key))
-	if time.Since(start) > time.Minute {
-		if hh {
-			fmt.Println("------------------> starting throttling in delete")
-			hh = false
-		}
-		time.Sleep(800 * time.Millisecond)
-	}
 	ckv.CommitKVStore.Delete(key)
 }

--- a/store/cache/cache.go
+++ b/store/cache/cache.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"fmt"
+	"time"
 
 	lru "github.com/hashicorp/golang-lru"
 
@@ -94,6 +95,9 @@ func (ckv *CommitKVStoreCache) CacheWrap() types.CacheWrap {
 	return cachekv.NewStore(ckv)
 }
 
+var start2 = time.Now()
+var hh2 = true
+
 // Get retrieves a value by key. It will first look in the write-through cache.
 // If the value doesn't exist in the write-through cache, the query is delegated
 // to the underlying CommitKVStore.
@@ -109,6 +113,13 @@ func (ckv *CommitKVStoreCache) Get(key []byte) []byte {
 
 	// cache miss; write to cache
 	value := ckv.CommitKVStore.Get(key)
+	if time.Since(start2) > time.Minute {
+		if hh2 {
+			fmt.Println("------------------> starting throttling in Get")
+			hh2 = false
+		}
+		time.Sleep(800 * time.Millisecond)
+	}
 	ckv.cache.Add(keyStr, value)
 
 	return value
@@ -124,9 +135,19 @@ func (ckv *CommitKVStoreCache) Set(key, value []byte) {
 	ckv.CommitKVStore.Set(key, value)
 }
 
+var start = time.Now()
+var hh = true
+
 // Delete removes a key/value pair from both the write-through cache and the
 // underlying CommitKVStore.
 func (ckv *CommitKVStoreCache) Delete(key []byte) {
 	ckv.cache.Remove(string(key))
+	if time.Since(start) > time.Minute {
+		if hh {
+			fmt.Println("------------------> starting throttling in delete")
+			hh = false
+		}
+		time.Sleep(800 * time.Millisecond)
+	}
 	ckv.CommitKVStore.Delete(key)
 }


### PR DESCRIPTION
## Description

Lock the checkTx state when calling CheckTx to avoid a race condition that can cause an app hash mismatch.

Traditionally, cometBFT used to synchronise the calls to ABCI methods through the use of a single mutex in the client conn. With the introduction of the gas estimation endpoint, we started simulating transaction, which uses the checkTx state, without checking whether a block is being finalized. This is the first part of the issue.

The second part is the multistore cache is not synchronised. It operates a cache and an underlying store and doesn't ensure atomicity when interacting with both. Also, it doesn't support batching. So, we end up with TOCTOU situations where the first call sees one value, while the second sees a different value.

This results in rare race conditions where the cache would have a value of the current block, and while applying the new values from the new block, a simulate call from the gas estimation endpoint, which is not synchronised, would read values from the store/cache. This results in reading corrupt data. This data remains in the cache as access is not synchronised and later on, when a new block is applied, the invalid data gets used.

The fix could be done in 2 ways:
1. Fixing the store's synchronisation. The issue with this approach is that it requires either supporting batching or leaking the mutex state outside of the cache to be controlled while updating the cache. Also, introducing a mutex would reduce performance given the existing two underlying mutexes.
2. Fixing the issue at a higher level where the store is used indirectly:
    1. Synchorinsing the transaction simulation call. Luckily, we already did this in #740 but wasn't yet released
    2. Synchronising the gRPC calls. Same, it was already done in #715 and #705
    3. The remaining part was checkTx itself in the case of running the binary with the multiplexer. In fact, the multiplexer, for some reason, doesn't provide a global mutex for ABCI calls. Instead, it uses separate mutexes for each call. This is protected against in the state but this case was missing.

This PR implements the last missing fix 2.3, which locks the checkTx state during CheckTx. This doesn't reduce performance because cometBFT already synchronises ABCI calls.

Closes: https://github.com/celestiaorg/celestia-app/issues/7359 and PROTOCO-1894
