### PR TITLE
fix: abort in-flight snapshots on Close

### DIFF
--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"math"
 	"sort"
-	"sync"
 	"strconv"
+	"sync"
 
 	"github.com/cockroachdb/errors"
 	abci "github.com/cometbft/cometbft/abci/types"
@@ -1053,22 +1053,20 @@ func (app *BaseApp) TxEncode(tx sdk.Tx) ([]byte, error) {
 func (app *BaseApp) Close() error {
 	var errs []error
 
-	// Close app.db (opened by cosmos-sdk/server/start.go call to openDB)
-	if app.db != nil {
-		app.logger.Info("Closing application.db")
-		if err := app.db.Close(); err != nil {
+	// Abort in-flight snapshots and close snapshots/metadata.db before application.db.
+	// Snapshot export reads application.db; closing the app DB first races with that work
+	// and can panic. See https://github.com/celestiaorg/celestia-app/issues/7252.
+	if app.snapshotManager != nil {
+		app.logger.Info("Closing snapshots/metadata.db")
+		if err := app.snapshotManager.Close(); err != nil {
 			errs = append(errs, err)
 		}
 	}
 
-	// Close app.snapshotManager
-	// - opened when app chains use cosmos-sdk/server/util.go/DefaultBaseappOptions (boilerplate)
-	// - which calls cosmos-sdk/server/util.go/GetSnapshotStore
-	// - which is passed to baseapp/options.go/SetSnapshot
-	// - to set app.snapshotManager = snapshots.NewManager
-	if app.snapshotManager != nil {
-		app.logger.Info("Closing snapshots/metadata.db")
-		if err := app.snapshotManager.Close(); err != nil {
+	// Close app.db (opened by cosmos-sdk/server/start.go call to openDB)
+	if app.db != nil {
+		app.logger.Info("Closing application.db")
+		if err := app.db.Close(); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/baseapp/baseapp_test.go
+++ b/baseapp/baseapp_test.go
@@ -53,7 +53,7 @@ type (
 		baseApp   *baseapp.BaseApp
 		cdc       *codec.ProtoCodec
 		txConfig  client.TxConfig
-		logBuffer *bytes.Buffer
+		logBuffer *syncedLogBuffer
 	}
 
 	SnapshotsConfig struct {
@@ -65,13 +65,38 @@ type (
 	}
 )
 
+// syncedLogBuffer is a bytes.Buffer safe for concurrent logger writes
+// (e.g. SnapshotIfApplicable goroutine racing BaseApp.Close).
+type syncedLogBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncedLogBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncedLogBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+func (b *syncedLogBuffer) Reset() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.buf.Reset()
+}
+
 func NewBaseAppSuite(t *testing.T, opts ...func(*baseapp.BaseApp)) *BaseAppSuite {
 	cdc := codectestutil.CodecOptions{}.NewCodec()
 	baseapptestutil.RegisterInterfaces(cdc.InterfaceRegistry())
 
 	txConfig := authtx.NewTxConfig(cdc, authtx.DefaultSignModes)
 	db := dbm.NewMemDB()
-	logBuffer := new(bytes.Buffer)
+	logBuffer := &syncedLogBuffer{}
 	logger := log.NewLogger(logBuffer, log.ColorOption(false))
 
 	app := baseapp.NewBaseApp(t.Name(), logger, db, txConfig.TxDecoder(), opts...)

--- a/baseapp/close_test.go
+++ b/baseapp/close_test.go
@@ -1,0 +1,123 @@
+package baseapp_test
+
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+	"testing"
+
+	abci "github.com/cometbft/cometbft/abci/types"
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	dbm "github.com/cosmos/cosmos-db"
+	"github.com/stretchr/testify/require"
+
+	pruningtypes "cosmossdk.io/store/pruning/types"
+	"cosmossdk.io/store/snapshots"
+	snapshottypes "cosmossdk.io/store/snapshots/types"
+
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	baseapptestutil "github.com/cosmos/cosmos-sdk/baseapp/testutil"
+	"github.com/cosmos/cosmos-sdk/testutil"
+	"github.com/cosmos/cosmos-sdk/testutil/testdata"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// TestBaseApp_Close_ClosesSnapshotsBeforeApplicationDB asserts shutdown order:
+// snapshot manager (and any in-flight export) before application.db.
+// Closing the app DB first races with SnapshotIfApplicable.
+// See https://github.com/celestiaorg/celestia-app/issues/7252.
+func TestBaseApp_Close_ClosesSnapshotsBeforeApplicationDB(t *testing.T) {
+	snapshotStore, err := snapshots.NewStore(dbm.NewMemDB(), testutil.GetTempDir(t))
+	require.NoError(t, err)
+
+	suite := NewBaseAppSuite(t,
+		baseapp.SetSnapshot(snapshotStore, snapshottypes.NewSnapshotOptions(1000, 1)),
+		baseapp.SetPruning(pruningtypes.NewPruningOptions(pruningtypes.PruningNothing)),
+	)
+
+	suite.logBuffer.Reset()
+	require.NoError(t, suite.baseApp.Close())
+
+	logs := suite.logBuffer.String()
+	snapIdx := strings.Index(logs, "Closing snapshots/metadata.db")
+	appIdx := strings.Index(logs, "Closing application.db")
+	require.NotEqual(t, -1, snapIdx, "expected snapshot close log, got: %s", logs)
+	require.NotEqual(t, -1, appIdx, "expected application.db close log, got: %s", logs)
+	require.Less(t, snapIdx, appIdx, "snapshots must close before application.db; logs:\n%s", logs)
+}
+
+// TestBaseApp_Close_WithInFlightSnapshot commits a snapshot-interval height with enough
+// state that async SnapshotIfApplicable is still running, then Close() must return
+// without panicking. Uses pruning-everything so Create's PruneSnapshotHeight path is
+// exercised (the HandleSnapshotHeight panic in https://github.com/celestiaorg/celestia-app/issues/7252).
+func TestBaseApp_Close_WithInFlightSnapshot(t *testing.T) {
+	snapshotStore, err := snapshots.NewStore(dbm.NewMemDB(), testutil.GetTempDir(t))
+	require.NoError(t, err)
+
+	const (
+		snapshotInterval = uint64(1)
+		blockTxs         = 4
+	)
+
+	suite := NewBaseAppSuite(t,
+		baseapp.SetSnapshot(snapshotStore, snapshottypes.NewSnapshotOptions(snapshotInterval, 1)),
+		baseapp.SetPruning(pruningtypes.NewPruningOptions(pruningtypes.PruningEverything)),
+	)
+	baseapptestutil.RegisterKeyValueServer(suite.baseApp.MsgServiceRouter(), MsgKeyValueImpl{})
+
+	_, err = suite.baseApp.InitChain(&abci.RequestInitChain{
+		ConsensusParams: &cmtproto.ConsensusParams{},
+	})
+	require.NoError(t, err)
+
+	r := rand.New(rand.NewSource(7252))
+	_, _, addr := testdata.KeyTestPubAddr()
+	txs := make([][]byte, 0, blockTxs)
+	keyCounter := 0
+	for txNum := 0; txNum < blockTxs; txNum++ {
+		msgs := make([]sdk.Msg, 0, 100)
+		for msgNum := 0; msgNum < 100; msgNum++ {
+			value := make([]byte, 10000)
+			_, err := r.Read(value)
+			require.NoError(t, err)
+			msgs = append(msgs, &baseapptestutil.MsgKeyValue{
+				Key:    []byte(fmt.Sprintf("%v", keyCounter)),
+				Value:  value,
+				Signer: addr.String(),
+			})
+			keyCounter++
+		}
+		builder := suite.txConfig.NewTxBuilder()
+		require.NoError(t, builder.SetMsgs(msgs...))
+		setTxSignature(t, builder, 0)
+		txBytes, err := suite.txConfig.TxEncoder()(builder.GetTx())
+		require.NoError(t, err)
+		txs = append(txs, txBytes)
+	}
+
+	_, err = suite.baseApp.FinalizeBlock(&abci.RequestFinalizeBlock{
+		Height: 1,
+		Txs:    txs,
+	})
+	require.NoError(t, err)
+
+	// Commit triggers SnapshotIfApplicable asynchronously; do not wait for it.
+	_, err = suite.baseApp.Commit()
+	require.NoError(t, err)
+
+	suite.logBuffer.Reset()
+	require.NotPanics(t, func() {
+		require.NoError(t, suite.baseApp.Close())
+	})
+
+	logs := suite.logBuffer.String()
+	snapIdx := strings.Index(logs, "Closing snapshots/metadata.db")
+	appIdx := strings.Index(logs, "Closing application.db")
+	require.NotEqual(t, -1, snapIdx, "expected snapshot close log, got: %s", logs)
+	require.NotEqual(t, -1, appIdx, "expected application.db close log, got: %s", logs)
+	require.Less(t, snapIdx, appIdx, "snapshots must close before application.db; logs:\n%s", logs)
+
+	// Further snapshot attempts must fail fast on the closed manager.
+	_, err = suite.baseApp.SnapshotManager().Create(1)
+	require.ErrorIs(t, err, snapshots.ErrAborted)
+}

--- a/store/CHANGELOG.md
+++ b/store/CHANGELOG.md
@@ -33,7 +33,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
-* (snapshots) [celestia-app#7252](https://github.com/celestiaorg/celestia-app/issues/7252) Abort in-flight snapshots on `Manager.Close`, wait for export work to unwind before closing the snapshot DB, and stop panicking in `HandleSnapshotHeight` on DB write errors (shutdown race with `application.db`).
+* (snapshots) [#7252](https://github.com/celestiaorg/celestia-app/issues/7252) Abort in-flight snapshots on `Manager.Close`, wait for export work to unwind before closing the snapshot DB, and stop panicking in `HandleSnapshotHeight` on DB write errors (shutdown race with `application.db`).
 
 ## v1.1.1 (September 06, 2024)
 

--- a/store/CHANGELOG.md
+++ b/store/CHANGELOG.md
@@ -29,6 +29,12 @@ Ref: https://keepachangelog.com/en/1.0.0/
 > With Cosmos SDK v2 (with store/v2), CometBFT has been pushed to the boundaries, so issues like this
 > are not expected to happen again.
 
+## Unreleased
+
+### Bug Fixes
+
+* (snapshots) [celestia-app#7252](https://github.com/celestiaorg/celestia-app/issues/7252) Abort in-flight snapshots on `Manager.Close`, wait for export work to unwind before closing the snapshot DB, and stop panicking in `HandleSnapshotHeight` on DB write errors (shutdown race with `application.db`).
+
 ## v1.1.1 (September 06, 2024)
 
 ### Improvements

--- a/store/CHANGELOG.md
+++ b/store/CHANGELOG.md
@@ -33,7 +33,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
-* (snapshots) [#7252](https://github.com/celestiaorg/celestia-app/issues/7252) Abort in-flight snapshots on `Manager.Close`, wait for export work to unwind before closing the snapshot DB, and stop panicking in `HandleSnapshotHeight` on DB write errors (shutdown race with `application.db`).
+* (snapshots) [#7252](https://github.com/celestiaorg/celestia-app/issues/7252) Abort in-flight snapshots on `Manager.Close`, wait for export work to unwind before closing the snapshot DB, and stop panicking in `HandleSnapshotHeight` on DB write errors (shutdown race with `application.db`). Aborted creates skip `PruneSnapshotHeight` (that height may remain unpruned); `HandleSnapshotHeight` persistence failures are logged instead of panicking, so heights kept only in memory can be lost across a crash.
 
 ## v1.1.1 (September 06, 2024)
 

--- a/store/pruning/manager.go
+++ b/store/pruning/manager.go
@@ -66,9 +66,13 @@ func (m *Manager) GetOptions() types.PruningOptions {
 }
 
 // HandleSnapshotHeight persists the snapshot height to be pruned at the next appropriate
-// height defined by the pruning strategy. It flushes the update to disk and panics if the flush fails.
+// height defined by the pruning strategy. It flushes the update to disk.
 // The input height must be greater than 0, and the pruning strategy must not be set to pruning nothing.
 // If either of these conditions is not met, this function does nothing.
+//
+// DB write errors are logged and ignored; panicking here can crash the process during
+// shutdown when application.db is already closed.
+// See https://github.com/celestiaorg/celestia-app/issues/7252.
 func (m *Manager) HandleSnapshotHeight(height int64) {
 	if m.opts.GetPruningStrategy() == types.PruningNothing || height <= 0 {
 		return
@@ -90,7 +94,7 @@ func (m *Manager) HandleSnapshotHeight(height int64) {
 
 	// flush the updates to disk so that they are not lost if crash happens.
 	if err := m.db.SetSync(pruneSnapshotHeightsKey, int64SliceToBytes(m.pruneSnapshotHeights)); err != nil {
-		panic(err)
+		m.logger.Error("failed to persist prune snapshot heights", "height", height, "err", err)
 	}
 }
 

--- a/store/pruning/manager_test.go
+++ b/store/pruning/manager_test.go
@@ -196,7 +196,7 @@ func TestPruningHeight_Inputs(t *testing.T) {
 	}
 }
 
-func TestHandleSnapshotHeight_DbErr_Panic(t *testing.T) {
+func TestHandleSnapshotHeight_DbErr_NoPanic(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	// Setup
@@ -208,13 +208,9 @@ func TestHandleSnapshotHeight_DbErr_Panic(t *testing.T) {
 	manager.SetOptions(types.NewPruningOptions(types.PruningEverything))
 	require.NotNil(t, manager)
 
-	defer func() {
-		if r := recover(); r == nil {
-			t.Fail()
-		}
-	}()
-
-	manager.HandleSnapshotHeight(10)
+	require.NotPanics(t, func() {
+		manager.HandleSnapshotHeight(10)
+	})
 }
 
 func TestHandleSnapshotHeight_LoadFromDisk(t *testing.T) {

--- a/store/rootmulti/snapshot_test.go
+++ b/store/rootmulti/snapshot_test.go
@@ -8,9 +8,12 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
+	"sync"
 	"testing"
+	"time"
 
 	dbm "github.com/cosmos/cosmos-db"
+	protoio "github.com/cosmos/gogoproto/io"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -302,6 +305,85 @@ func benchmarkMultistoreSnapshotRestore(b *testing.B, stores uint8, storeKeys ui
 		require.NoError(b, err)
 		require.Equal(b, source.LastCommitID(), target.LastCommitID())
 	}
+}
+
+// signalingSnapshotter wraps a real Snapshotter and signals when Snapshot begins so
+// tests can Close the manager mid-IAVL export.
+type signalingSnapshotter struct {
+	inner   snapshottypes.Snapshotter
+	entered chan struct{}
+	once    sync.Once
+}
+
+func (s *signalingSnapshotter) Snapshot(height uint64, protoWriter protoio.Writer) error {
+	s.once.Do(func() { close(s.entered) })
+	return s.inner.Snapshot(height, protoWriter)
+}
+
+func (s *signalingSnapshotter) PruneSnapshotHeight(height int64) {
+	s.inner.PruneSnapshotHeight(height)
+}
+
+func (s *signalingSnapshotter) SetSnapshotInterval(snapshotInterval uint64) {
+	s.inner.SetSnapshotInterval(snapshotInterval)
+}
+
+func (s *signalingSnapshotter) Restore(height uint64, format uint32, protoReader protoio.Reader) (snapshottypes.SnapshotItem, error) {
+	return s.inner.Restore(height, format, protoReader)
+}
+
+// TestMultistoreSnapshot_ManagerCloseAbortsExport starts a real rootmulti/IAVL
+// snapshot via snapshots.Manager, then Close() mid-export. Create must return
+// ErrAborted and must not leave the process panicking.
+// See https://github.com/celestiaorg/celestia-app/issues/7252.
+func TestMultistoreSnapshot_ManagerCloseAbortsExport(t *testing.T) {
+	// Large enough that export outlives the test's Close after "entered".
+	multiStore := newMultiStoreWithGeneratedData(dbm.NewMemDB(), 5, 10000)
+	version := uint64(multiStore.LastCommitID().Version)
+	require.EqualValues(t, 1, version)
+
+	snapshotDB := dbm.NewMemDB()
+	snapshotStore, err := snapshots.NewStore(snapshotDB, t.TempDir())
+	require.NoError(t, err)
+
+	gate := &signalingSnapshotter{
+		inner:   multiStore,
+		entered: make(chan struct{}),
+	}
+	opts := snapshottypes.NewSnapshotOptions(1, 1)
+	manager := snapshots.NewManager(snapshotStore, opts, gate, nil, log.NewNopLogger())
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := manager.Create(version)
+		errCh <- err
+	}()
+
+	select {
+	case <-gate.entered:
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for rootmulti Snapshot to start")
+	}
+
+	require.NoError(t, manager.Close())
+
+	select {
+	case err := <-errCh:
+		require.ErrorIs(t, err, snapshots.ErrAborted)
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for Create to abort after Manager.Close")
+	}
+
+	// App state DB must remain usable; Manager.Close only closes snapshot metadata.
+	require.EqualValues(t, 1, multiStore.LastCommitID().Version)
+	store0 := multiStore.GetStoreByName("store0").(types.KVStore)
+	key := make([]byte, 8)
+	binary.BigEndian.PutUint64(key, 0)
+	require.NotNil(t, store0.Get(key))
+
+	// Closed manager rejects new work.
+	_, err = manager.Create(version)
+	require.ErrorIs(t, err, snapshots.ErrAborted)
 }
 
 func BenchmarkMultistoreSnapshot100K(b *testing.B) {

--- a/store/rootmulti/snapshot_test.go
+++ b/store/rootmulti/snapshot_test.go
@@ -328,6 +328,15 @@ func (s *signalingSnapshotter) SetSnapshotInterval(snapshotInterval uint64) {
 	s.inner.SetSnapshotInterval(snapshotInterval)
 }
 
+func (s *signalingSnapshotter) SetSnapshotAbortCh(abort <-chan struct{}) {
+	type abortAware interface {
+		SetSnapshotAbortCh(<-chan struct{})
+	}
+	if a, ok := s.inner.(abortAware); ok {
+		a.SetSnapshotAbortCh(abort)
+	}
+}
+
 func (s *signalingSnapshotter) Restore(height uint64, format uint32, protoReader protoio.Reader) (snapshottypes.SnapshotItem, error) {
 	return s.inner.Restore(height, format, protoReader)
 }

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -58,8 +58,8 @@ func keysFromStoreKeyMap[V any](m map[types.StoreKey]V) []types.StoreKey {
 type Store struct {
 	db                  dbm.DB
 	logger              log.Logger
-	lastCommitInfo   *types.CommitInfo
-	lastCommitInfoMu sync.RWMutex
+	lastCommitInfo      *types.CommitInfo
+	lastCommitInfoMu    sync.RWMutex
 	pruningManager      *pruning.Manager
 	iavlCacheSize       int
 	iavlDisableFastNode bool
@@ -75,6 +75,11 @@ type Store struct {
 	listeners           map[types.StoreKey]*types.MemoryListener
 	metrics             metrics.StoreMetrics
 	commitHeader        cmtproto.Header
+
+	// snapshotAbortCh is set by snapshots.Manager so Snapshot can observe shutdown
+	// before/between writes (not only when WriteMsg fails).
+	snapshotAbortChMu sync.RWMutex
+	snapshotAbortCh   <-chan struct{}
 }
 
 var (
@@ -123,6 +128,29 @@ func (rs *Store) SetMetrics(metrics metrics.StoreMetrics) {
 // It is used by the store to determine which heights to retain until after the snapshot is complete.
 func (rs *Store) SetSnapshotInterval(snapshotInterval uint64) {
 	rs.pruningManager.SetSnapshotInterval(snapshotInterval)
+}
+
+// SetSnapshotAbortCh registers a channel closed by snapshots.Manager on Close so
+// Snapshot can return early when shutdown begins, including before the first WriteMsg.
+func (rs *Store) SetSnapshotAbortCh(abort <-chan struct{}) {
+	rs.snapshotAbortChMu.Lock()
+	defer rs.snapshotAbortChMu.Unlock()
+	rs.snapshotAbortCh = abort
+}
+
+func (rs *Store) snapshotAborted() bool {
+	rs.snapshotAbortChMu.RLock()
+	ch := rs.snapshotAbortCh
+	rs.snapshotAbortChMu.RUnlock()
+	if ch == nil {
+		return false
+	}
+	select {
+	case <-ch:
+		return true
+	default:
+		return false
+	}
 }
 
 func (rs *Store) SetIAVLCacheSize(cacheSize int) {
@@ -872,6 +900,10 @@ func (rs *Store) Snapshot(height uint64, protoWriter protoio.Writer) error {
 	// and the following messages contain a SnapshotNode (i.e. an ExportNode). Store changes
 	// are demarcated by new SnapshotStore items.
 	for _, store := range stores {
+		if rs.snapshotAborted() {
+			return snapshottypes.ErrAborted
+		}
+
 		rs.logger.Trace("starting snapshot", "store", store.name, "height", height)
 		exporter, err := store.Export(int64(height))
 		if err != nil {
@@ -881,6 +913,10 @@ func (rs *Store) Snapshot(height uint64, protoWriter protoio.Writer) error {
 
 		err = func() error {
 			defer exporter.Close()
+
+			if rs.snapshotAborted() {
+				return snapshottypes.ErrAborted
+			}
 
 			err := protoWriter.WriteMsg(&snapshottypes.SnapshotItem{
 				Item: &snapshottypes.SnapshotItem_Store{
@@ -896,6 +932,9 @@ func (rs *Store) Snapshot(height uint64, protoWriter protoio.Writer) error {
 
 			nodeCount := 0
 			for {
+				if rs.snapshotAborted() {
+					return snapshottypes.ErrAborted
+				}
 				node, err := exporter.Next()
 				if err == iavltree.ErrorExportDone {
 					rs.logger.Trace("snapshot Done", "store", store.name, "nodeCount", nodeCount)

--- a/store/snapshots/chunk.go
+++ b/store/snapshots/chunk.go
@@ -3,7 +3,6 @@ package snapshots
 import (
 	"io"
 	"math"
-	"sync"
 
 	"cosmossdk.io/errors"
 	snapshottypes "cosmossdk.io/store/snapshots/types"
@@ -12,15 +11,7 @@ import (
 
 // ChunkWriter reads an input stream, splits it into fixed-size chunks, and writes them to a
 // sequence of io.ReadClosers via a channel.
-//
-// Close / CloseWithError may run concurrently with Write (e.g. Manager.Close aborting an
-// in-flight snapshot). pipe.Write is never called while mtx is held so CloseWithError can
-// unblock a writer via pipe.CloseWithError. Channel close is done under mtx so it cannot
-// race with a send (sending on a closed channel panics).
 type ChunkWriter struct {
-	mtx         sync.Mutex
-	closeChOnce sync.Once
-
 	ch        chan<- io.ReadCloser
 	pipe      *io.PipeWriter
 	chunkSize uint64
@@ -36,137 +27,81 @@ func NewChunkWriter(ch chan<- io.ReadCloser, chunkSize uint64) *ChunkWriter {
 	}
 }
 
-// chunkLocked creates a new chunk. Caller must hold w.mtx.
-func (w *ChunkWriter) chunkLocked() error {
+// chunk creates a new chunk.
+func (w *ChunkWriter) chunk() error {
 	if w.pipe != nil {
-		pipe := w.pipe
-		w.pipe = nil
-		w.mtx.Unlock()
-		err := pipe.Close()
-		w.mtx.Lock()
+		err := w.pipe.Close()
 		if err != nil {
 			return err
 		}
-		if w.closed {
-			return errors.Wrap(storetypes.ErrLogic, "cannot write to closed ChunkWriter")
-		}
 	}
-
-	if w.closed {
-		return errors.Wrap(storetypes.ErrLogic, "cannot write to closed ChunkWriter")
-	}
-
 	pr, pw := io.Pipe()
-	// Hold the lock across the channel send so CloseWithError cannot close the channel
-	// concurrently (sending on a closed channel panics).
 	w.ch <- pr
 	w.pipe = pw
 	w.written = 0
 	return nil
 }
 
-func (w *ChunkWriter) closeChannelLocked() {
-	w.closeChOnce.Do(func() {
-		close(w.ch)
-	})
-}
-
 // Close implements io.Closer.
 func (w *ChunkWriter) Close() error {
-	w.mtx.Lock()
-	if w.closed {
-		w.mtx.Unlock()
-		return nil
-	}
-	w.closed = true
-	pipe := w.pipe
-	w.pipe = nil
-	w.closeChannelLocked()
-	w.mtx.Unlock()
-
-	if pipe != nil {
-		return pipe.Close()
+	if !w.closed {
+		w.closed = true
+		close(w.ch)
+		var err error
+		if w.pipe != nil {
+			err = w.pipe.Close()
+		}
+		return err
 	}
 	return nil
 }
 
 // CloseWithError closes the writer and sends an error to the reader.
-// Safe to call concurrently with Write.
 func (w *ChunkWriter) CloseWithError(err error) {
-	w.mtx.Lock()
-	if w.closed {
-		w.mtx.Unlock()
-		return
+	if !w.closed {
+		if w.pipe == nil {
+			// create a dummy pipe just to propagate the error to the reader, it always returns nil
+			_ = w.chunk()
+		}
+		w.closed = true
+		close(w.ch)
+		_ = w.pipe.CloseWithError(err) // CloseWithError always returns nil
 	}
-	w.closed = true
-
-	// Historical behavior: if no chunk exists yet, create a dummy one so Save observes
-	// the error instead of completing an empty snapshot successfully.
-	if w.pipe == nil {
-		pr, pw := io.Pipe()
-		w.ch <- pr
-		w.pipe = pw
-	}
-	pipe := w.pipe
-	w.pipe = nil
-	w.closeChannelLocked()
-	w.mtx.Unlock()
-
-	_ = pipe.CloseWithError(err)
 }
 
 // Write implements io.Writer.
 func (w *ChunkWriter) Write(data []byte) (int, error) {
+	if w.closed {
+		return 0, errors.Wrap(storetypes.ErrLogic, "cannot write to closed ChunkWriter")
+	}
 	nTotal := 0
 	for len(data) > 0 {
-		pipe, writeSize, err := w.prepareWrite(len(data))
-		if err != nil {
-			return nTotal, err
+		if w.pipe == nil || (w.written >= w.chunkSize && w.chunkSize > 0) {
+			err := w.chunk()
+			if err != nil {
+				return nTotal, err
+			}
 		}
 
-		n, err := pipe.Write(data[:writeSize])
-		if n > 0 {
-			w.addWritten(pipe, n)
-			nTotal += n
+		var writeSize uint64
+		if w.chunkSize == 0 {
+			writeSize = uint64(len(data))
+		} else {
+			writeSize = w.chunkSize - w.written
 		}
+		if writeSize > uint64(len(data)) {
+			writeSize = uint64(len(data))
+		}
+
+		n, err := w.pipe.Write(data[:writeSize])
+		w.written += uint64(n)
+		nTotal += n
 		if err != nil {
 			return nTotal, err
 		}
 		data = data[writeSize:]
 	}
 	return nTotal, nil
-}
-
-func (w *ChunkWriter) prepareWrite(dataLen int) (*io.PipeWriter, int, error) {
-	w.mtx.Lock()
-	defer w.mtx.Unlock()
-
-	if w.closed {
-		return nil, 0, errors.Wrap(storetypes.ErrLogic, "cannot write to closed ChunkWriter")
-	}
-
-	for w.pipe == nil || (w.chunkSize > 0 && w.written >= w.chunkSize) {
-		if err := w.chunkLocked(); err != nil {
-			return nil, 0, err
-		}
-	}
-
-	writeSize := dataLen
-	if w.chunkSize > 0 {
-		remaining := int(w.chunkSize - w.written)
-		if writeSize > remaining {
-			writeSize = remaining
-		}
-	}
-	return w.pipe, writeSize, nil
-}
-
-func (w *ChunkWriter) addWritten(pipe *io.PipeWriter, n int) {
-	w.mtx.Lock()
-	defer w.mtx.Unlock()
-	if w.pipe == pipe {
-		w.written += uint64(n)
-	}
 }
 
 // ChunkReader reads chunks from a channel of io.ReadClosers and outputs them as an io.Reader

--- a/store/snapshots/chunk.go
+++ b/store/snapshots/chunk.go
@@ -3,6 +3,7 @@ package snapshots
 import (
 	"io"
 	"math"
+	"sync"
 
 	"cosmossdk.io/errors"
 	snapshottypes "cosmossdk.io/store/snapshots/types"
@@ -11,7 +12,15 @@ import (
 
 // ChunkWriter reads an input stream, splits it into fixed-size chunks, and writes them to a
 // sequence of io.ReadClosers via a channel.
+//
+// Close / CloseWithError may run concurrently with Write (e.g. Manager.Close aborting an
+// in-flight snapshot). pipe.Write is never called while mtx is held so CloseWithError can
+// unblock a writer via pipe.CloseWithError. Channel close is done under mtx so it cannot
+// race with a send (sending on a closed channel panics).
 type ChunkWriter struct {
+	mtx         sync.Mutex
+	closeChOnce sync.Once
+
 	ch        chan<- io.ReadCloser
 	pipe      *io.PipeWriter
 	chunkSize uint64
@@ -27,81 +36,137 @@ func NewChunkWriter(ch chan<- io.ReadCloser, chunkSize uint64) *ChunkWriter {
 	}
 }
 
-// chunk creates a new chunk.
-func (w *ChunkWriter) chunk() error {
+// chunkLocked creates a new chunk. Caller must hold w.mtx.
+func (w *ChunkWriter) chunkLocked() error {
 	if w.pipe != nil {
-		err := w.pipe.Close()
+		pipe := w.pipe
+		w.pipe = nil
+		w.mtx.Unlock()
+		err := pipe.Close()
+		w.mtx.Lock()
 		if err != nil {
 			return err
 		}
+		if w.closed {
+			return errors.Wrap(storetypes.ErrLogic, "cannot write to closed ChunkWriter")
+		}
 	}
+
+	if w.closed {
+		return errors.Wrap(storetypes.ErrLogic, "cannot write to closed ChunkWriter")
+	}
+
 	pr, pw := io.Pipe()
+	// Hold the lock across the channel send so CloseWithError cannot close the channel
+	// concurrently (sending on a closed channel panics).
 	w.ch <- pr
 	w.pipe = pw
 	w.written = 0
 	return nil
 }
 
+func (w *ChunkWriter) closeChannelLocked() {
+	w.closeChOnce.Do(func() {
+		close(w.ch)
+	})
+}
+
 // Close implements io.Closer.
 func (w *ChunkWriter) Close() error {
-	if !w.closed {
-		w.closed = true
-		close(w.ch)
-		var err error
-		if w.pipe != nil {
-			err = w.pipe.Close()
-		}
-		return err
+	w.mtx.Lock()
+	if w.closed {
+		w.mtx.Unlock()
+		return nil
+	}
+	w.closed = true
+	pipe := w.pipe
+	w.pipe = nil
+	w.closeChannelLocked()
+	w.mtx.Unlock()
+
+	if pipe != nil {
+		return pipe.Close()
 	}
 	return nil
 }
 
 // CloseWithError closes the writer and sends an error to the reader.
+// Safe to call concurrently with Write.
 func (w *ChunkWriter) CloseWithError(err error) {
-	if !w.closed {
-		if w.pipe == nil {
-			// create a dummy pipe just to propagate the error to the reader, it always returns nil
-			_ = w.chunk()
-		}
-		w.closed = true
-		close(w.ch)
-		_ = w.pipe.CloseWithError(err) // CloseWithError always returns nil
+	w.mtx.Lock()
+	if w.closed {
+		w.mtx.Unlock()
+		return
 	}
+	w.closed = true
+
+	// Historical behavior: if no chunk exists yet, create a dummy one so Save observes
+	// the error instead of completing an empty snapshot successfully.
+	if w.pipe == nil {
+		pr, pw := io.Pipe()
+		w.ch <- pr
+		w.pipe = pw
+	}
+	pipe := w.pipe
+	w.pipe = nil
+	w.closeChannelLocked()
+	w.mtx.Unlock()
+
+	_ = pipe.CloseWithError(err)
 }
 
 // Write implements io.Writer.
 func (w *ChunkWriter) Write(data []byte) (int, error) {
-	if w.closed {
-		return 0, errors.Wrap(storetypes.ErrLogic, "cannot write to closed ChunkWriter")
-	}
 	nTotal := 0
 	for len(data) > 0 {
-		if w.pipe == nil || (w.written >= w.chunkSize && w.chunkSize > 0) {
-			err := w.chunk()
-			if err != nil {
-				return nTotal, err
-			}
+		pipe, writeSize, err := w.prepareWrite(len(data))
+		if err != nil {
+			return nTotal, err
 		}
 
-		var writeSize uint64
-		if w.chunkSize == 0 {
-			writeSize = uint64(len(data))
-		} else {
-			writeSize = w.chunkSize - w.written
+		n, err := pipe.Write(data[:writeSize])
+		if n > 0 {
+			w.addWritten(pipe, n)
+			nTotal += n
 		}
-		if writeSize > uint64(len(data)) {
-			writeSize = uint64(len(data))
-		}
-
-		n, err := w.pipe.Write(data[:writeSize])
-		w.written += uint64(n)
-		nTotal += n
 		if err != nil {
 			return nTotal, err
 		}
 		data = data[writeSize:]
 	}
 	return nTotal, nil
+}
+
+func (w *ChunkWriter) prepareWrite(dataLen int) (*io.PipeWriter, int, error) {
+	w.mtx.Lock()
+	defer w.mtx.Unlock()
+
+	if w.closed {
+		return nil, 0, errors.Wrap(storetypes.ErrLogic, "cannot write to closed ChunkWriter")
+	}
+
+	for w.pipe == nil || (w.chunkSize > 0 && w.written >= w.chunkSize) {
+		if err := w.chunkLocked(); err != nil {
+			return nil, 0, err
+		}
+	}
+
+	writeSize := dataLen
+	if w.chunkSize > 0 {
+		remaining := int(w.chunkSize - w.written)
+		if writeSize > remaining {
+			writeSize = remaining
+		}
+	}
+	return w.pipe, writeSize, nil
+}
+
+func (w *ChunkWriter) addWritten(pipe *io.PipeWriter, n int) {
+	w.mtx.Lock()
+	defer w.mtx.Unlock()
+	if w.pipe == pipe {
+		w.written += uint64(n)
+	}
 }
 
 // ChunkReader reads chunks from a channel of io.ReadClosers and outputs them as an io.Reader

--- a/store/snapshots/helpers_test.go
+++ b/store/snapshots/helpers_test.go
@@ -244,8 +244,6 @@ func setupBusyManager(t *testing.T) *snapshots.Manager {
 // hungSnapshotter can be used to test operations in progress. Call Close to end the snapshot.
 type hungSnapshotter struct {
 	ch               chan struct{}
-	entered          chan struct{}
-	enteredOnce      sync.Once
 	closeOnce        sync.Once
 	prunedHeights    map[int64]struct{}
 	snapshotInterval uint64
@@ -254,7 +252,6 @@ type hungSnapshotter struct {
 func newHungSnapshotter() *hungSnapshotter {
 	return &hungSnapshotter{
 		ch:            make(chan struct{}),
-		entered:       make(chan struct{}),
 		prunedHeights: make(map[int64]struct{}),
 	}
 }
@@ -266,9 +263,6 @@ func (m *hungSnapshotter) Close() {
 }
 
 func (m *hungSnapshotter) Snapshot(height uint64, protoWriter protoio.Writer) error {
-	m.enteredOnce.Do(func() {
-		close(m.entered)
-	})
 	<-m.ch
 	return nil
 }

--- a/store/snapshots/helpers_test.go
+++ b/store/snapshots/helpers_test.go
@@ -205,7 +205,10 @@ func (m *mockErrorSnapshotter) SetSnapshotInterval(snapshotInterval uint64) {
 }
 
 // setupBusyManager creates a manager with an empty store that is busy creating a snapshot at height 1.
-// The snapshot will complete when the returned closer is called.
+// The snapshot completes when hungSnapshotter.Close runs (via t.Cleanup).
+//
+// Do not call manager.Close() while the hung snapshotter is blocked: Close waits for the
+// in-flight Create to observe abort on WriteMsg, and hungSnapshotter never writes.
 func setupBusyManager(t *testing.T) *snapshots.Manager {
 	t.Helper()
 	store, err := snapshots.NewStore(db.NewMemDB(), t.TempDir())
@@ -223,11 +226,7 @@ func setupBusyManager(t *testing.T) *snapshots.Manager {
 	go func() {
 		defer close(done)
 		_, err := mgr.Create(1)
-		// Manager.Close may abort an in-flight Create; that is expected.
-		if err != nil {
-			require.ErrorIs(t, err, snapshots.ErrAborted)
-			return
-		}
+		require.NoError(t, err)
 		_, didPruneHeight := hung.prunedHeights[1]
 		require.True(t, didPruneHeight)
 	}()
@@ -242,10 +241,9 @@ func setupBusyManager(t *testing.T) *snapshots.Manager {
 	return mgr
 }
 
-// hungSnapshotter can be used to test operations in progress. Call close to end the snapshot.
+// hungSnapshotter can be used to test operations in progress. Call Close to end the snapshot.
 type hungSnapshotter struct {
 	ch               chan struct{}
-	abortCh          <-chan struct{}
 	entered          chan struct{}
 	enteredOnce      sync.Once
 	closeOnce        sync.Once
@@ -261,10 +259,6 @@ func newHungSnapshotter() *hungSnapshotter {
 	}
 }
 
-func (m *hungSnapshotter) SetSnapshotAbortCh(abort <-chan struct{}) {
-	m.abortCh = abort
-}
-
 func (m *hungSnapshotter) Close() {
 	m.closeOnce.Do(func() {
 		close(m.ch)
@@ -275,12 +269,8 @@ func (m *hungSnapshotter) Snapshot(height uint64, protoWriter protoio.Writer) er
 	m.enteredOnce.Do(func() {
 		close(m.entered)
 	})
-	select {
-	case <-m.ch:
-		return nil
-	case <-m.abortCh:
-		return snapshots.ErrAborted
-	}
+	<-m.ch
+	return nil
 }
 
 func (m *hungSnapshotter) PruneSnapshotHeight(height int64) {

--- a/store/snapshots/helpers_test.go
+++ b/store/snapshots/helpers_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -222,7 +223,11 @@ func setupBusyManager(t *testing.T) *snapshots.Manager {
 	go func() {
 		defer close(done)
 		_, err := mgr.Create(1)
-		require.NoError(t, err)
+		// Manager.Close may abort an in-flight Create; that is expected.
+		if err != nil {
+			require.ErrorIs(t, err, snapshots.ErrAborted)
+			return
+		}
 		_, didPruneHeight := hung.prunedHeights[1]
 		require.True(t, didPruneHeight)
 	}()
@@ -240,6 +245,10 @@ func setupBusyManager(t *testing.T) *snapshots.Manager {
 // hungSnapshotter can be used to test operations in progress. Call close to end the snapshot.
 type hungSnapshotter struct {
 	ch               chan struct{}
+	abortCh          <-chan struct{}
+	entered          chan struct{}
+	enteredOnce      sync.Once
+	closeOnce        sync.Once
 	prunedHeights    map[int64]struct{}
 	snapshotInterval uint64
 }
@@ -247,17 +256,31 @@ type hungSnapshotter struct {
 func newHungSnapshotter() *hungSnapshotter {
 	return &hungSnapshotter{
 		ch:            make(chan struct{}),
+		entered:       make(chan struct{}),
 		prunedHeights: make(map[int64]struct{}),
 	}
 }
 
+func (m *hungSnapshotter) SetSnapshotAbortCh(abort <-chan struct{}) {
+	m.abortCh = abort
+}
+
 func (m *hungSnapshotter) Close() {
-	close(m.ch)
+	m.closeOnce.Do(func() {
+		close(m.ch)
+	})
 }
 
 func (m *hungSnapshotter) Snapshot(height uint64, protoWriter protoio.Writer) error {
-	<-m.ch
-	return nil
+	m.enteredOnce.Do(func() {
+		close(m.entered)
+	})
+	select {
+	case <-m.ch:
+		return nil
+	case <-m.abortCh:
+		return snapshots.ErrAborted
+	}
 }
 
 func (m *hungSnapshotter) PruneSnapshotHeight(height int64) {

--- a/store/snapshots/manager.go
+++ b/store/snapshots/manager.go
@@ -635,26 +635,23 @@ func (m *Manager) snapshot(height int64) {
 	}
 }
 
-// Close aborts any in-flight snapshot/restore work, waits for it to stop touching
+// Close aborts in-flight snapshot/restore work, waits until it stops touching
 // application state, then closes the snapshot metadata database.
 //
-// Close does not wait for a full snapshot to finish being created; it cancels
-// in-flight work and waits only until that work returns (in particular until
-// Snapshot() has returned), so application.db is not closed under a live export.
-// Abort is observed on the next WriteMsg (abortAwareWriter), and by snapshotters
-// that honor SetSnapshotAbortCh (including rootmulti before/between export writes).
-// Snapshotters that ignore abort and never return can delay Close indefinitely;
-// returning earlier would reintroduce read-after-close panics on application.db.
+// It cancels work rather than waiting for a full snapshot to finish, but still
+// waits until Snapshot() (or restore) returns so application.db is not closed
+// under a live export. Abort is observed via abortAwareWriter on WriteMsg and
+// via SetSnapshotAbortCh (rootmulti). Snapshotters that ignore abort and never
+// return can delay Close; returning earlier would reintroduce #7252 panics.
 //
-// Concurrent Close callers share completion: the first performs shutdown, others
-// wait and return the same error. This prevents a second Close from returning
-// before the snapshot manager has finished, which would allow BaseApp to close
-// application.db while export work is still running.
+// Concurrent Close callers share completion so a second Close cannot return and
+// let BaseApp close application.db while export work is still running.
 func (m *Manager) Close() error {
 	if m == nil {
 		return nil
 	}
 
+	// Followers wait for the leader's shutdown to finish (same result).
 	m.mtx.Lock()
 	if m.closeCh != nil {
 		ch := m.closeCh
@@ -662,21 +659,44 @@ func (m *Manager) Close() error {
 		<-ch
 		return m.closeErr
 	}
-
 	closeCh := make(chan struct{})
 	m.closeCh = closeCh
+
+	// Reject new work and wake exporters that observe abortCh.
 	m.closed = true
 	close(m.abortCh)
 
+	// Detach restore channels under the lock. RestoreChunk may already have
+	// closed chRestore on the final chunk; nil both fields so Close owns the
+	// local copies and we do not double-close.
 	chRestore := m.chRestore
 	chRestoreDone := m.chRestoreDone
-	op := m.operation
-	// Avoid double-close if RestoreChunk already closed the channel.
 	m.chRestore = nil
+	m.chRestoreDone = nil
 	m.mtx.Unlock()
 
-	m.abortRestore(chRestore, chRestoreDone, op)
-	m.waitOperationIdle()
+	// Unblock an in-flight async restore, then clear opRestore once its goroutine
+	// exits. Do not hold mtx while waiting: RestoreChunk can hold mtx on the same
+	// done channel. The restore goroutine does not call endLocked itself — only
+	// RestoreChunk or Close does — so Close must end the op after <-chRestoreDone.
+	if chRestore != nil {
+		close(chRestore)
+	}
+	if chRestoreDone != nil {
+		<-chRestoreDone
+		m.mtx.Lock()
+		if m.operation == opRestore {
+			m.endLocked()
+		}
+		m.mtx.Unlock()
+	}
+
+	// Wait for any remaining operation (Create / Prune / RestoreLocalSnapshot).
+	m.mtx.Lock()
+	for m.operation != opNone {
+		m.idle.Wait()
+	}
+	m.mtx.Unlock()
 
 	err := m.store.db.Close()
 
@@ -685,29 +705,4 @@ func (m *Manager) Close() error {
 	close(closeCh)
 	m.mtx.Unlock()
 	return err
-}
-
-// abortRestore stops an in-flight restore, if any, and clears opRestore.
-func (m *Manager) abortRestore(chRestore chan<- uint32, chRestoreDone <-chan restoreDone, op operation) {
-	if chRestore != nil {
-		close(chRestore)
-	}
-	if op != opRestore || chRestoreDone == nil {
-		return
-	}
-	<-chRestoreDone
-	m.mtx.Lock()
-	if m.operation == opRestore {
-		m.endLocked()
-	}
-	m.mtx.Unlock()
-}
-
-// waitOperationIdle blocks until no manager operation is in progress.
-func (m *Manager) waitOperationIdle() {
-	m.mtx.Lock()
-	for m.operation != opNone {
-		m.idle.Wait()
-	}
-	m.mtx.Unlock()
 }

--- a/store/snapshots/manager.go
+++ b/store/snapshots/manager.go
@@ -46,6 +46,8 @@ type Manager struct {
 	operation         operation
 	closed            bool
 	abortCh           chan struct{}
+	closeCh           chan struct{} // non-nil once Close starts; closed when Close fully finishes
+	closeErr          error         // result of Close; stable after closeCh is closed
 	chRestore         chan<- uint32
 	chRestoreDone     <-chan restoreDone
 	restoreSnapshot   *types.Snapshot
@@ -76,8 +78,14 @@ const (
 var (
 	ErrOptsZeroSnapshotInterval = errors.New("snaphot-interval must not be 0")
 	// ErrAborted is returned when a snapshot operation is canceled because the manager is closing.
-	ErrAborted = errors.New("snapshot aborted")
+	ErrAborted = types.ErrAborted
 )
+
+// snapshotAbortAware is optionally implemented by snapshotters that can observe
+// manager shutdown before or between WriteMsg calls (e.g. rootmulti during IAVL export).
+type snapshotAbortAware interface {
+	SetSnapshotAbortCh(abort <-chan struct{})
+}
 
 // NewManager creates a new manager.
 func NewManager(store *Store, opts types.SnapshotOptions, multistore types.Snapshotter, extensions map[string]types.ExtensionSnapshotter, logger log.Logger) *Manager {
@@ -93,6 +101,9 @@ func NewManager(store *Store, opts types.SnapshotOptions, multistore types.Snaps
 		abortCh:    make(chan struct{}),
 	}
 	m.idle = sync.NewCond(&m.mtx)
+	if a, ok := multistore.(snapshotAbortAware); ok {
+		a.SetSnapshotAbortCh(m.abortCh)
+	}
 	return m
 }
 
@@ -354,6 +365,8 @@ func (m *Manager) Restore(snapshot types.Snapshot) error {
 
 	dir := m.store.pathSnapshot(snapshot.Height, snapshot.Format)
 	if err := os.MkdirAll(dir, 0o750); err != nil {
+		// Roll back the operation so Close is not left waiting on opRestore forever.
+		m.endLocked()
 		return errorsmod.Wrapf(err, "failed to create snapshot directory %q", dir)
 	}
 
@@ -625,19 +638,33 @@ func (m *Manager) snapshot(height int64) {
 // Close aborts any in-flight snapshot/restore work, waits for it to stop touching
 // application state, then closes the snapshot metadata database.
 //
-// Close does not wait for a snapshot to finish being created; it cancels in-flight
-// work and only waits for that work to unwind. Abort is observed on the next
-// WriteMsg after any in-flight chunk write is consumed by Save.
+// Close does not wait for a full snapshot to finish being created; it cancels
+// in-flight work and waits only until that work returns (in particular until
+// Snapshot() has returned), so application.db is not closed under a live export.
+// Abort is observed on the next WriteMsg (abortAwareWriter), and by snapshotters
+// that honor SetSnapshotAbortCh (including rootmulti before/between export writes).
+// Snapshotters that ignore abort and never return can delay Close indefinitely;
+// returning earlier would reintroduce read-after-close panics on application.db.
+//
+// Concurrent Close callers share completion: the first performs shutdown, others
+// wait and return the same error. This prevents a second Close from returning
+// before the snapshot manager has finished, which would allow BaseApp to close
+// application.db while export work is still running.
 func (m *Manager) Close() error {
 	if m == nil {
 		return nil
 	}
 
 	m.mtx.Lock()
-	if m.closed {
+	if m.closeCh != nil {
+		ch := m.closeCh
 		m.mtx.Unlock()
-		return nil
+		<-ch
+		return m.closeErr
 	}
+
+	closeCh := make(chan struct{})
+	m.closeCh = closeCh
 	m.closed = true
 	close(m.abortCh)
 
@@ -646,25 +673,41 @@ func (m *Manager) Close() error {
 	op := m.operation
 	// Avoid double-close if RestoreChunk already closed the channel.
 	m.chRestore = nil
+	m.mtx.Unlock()
 
+	m.abortRestore(chRestore, chRestoreDone, op)
+	m.waitOperationIdle()
+
+	err := m.store.db.Close()
+
+	m.mtx.Lock()
+	m.closeErr = err
+	close(closeCh)
+	m.mtx.Unlock()
+	return err
+}
+
+// abortRestore stops an in-flight restore, if any, and clears opRestore.
+func (m *Manager) abortRestore(chRestore chan<- uint32, chRestoreDone <-chan restoreDone, op operation) {
 	if chRestore != nil {
-		m.mtx.Unlock()
 		close(chRestore)
-		m.mtx.Lock()
 	}
-	if op == opRestore && chRestoreDone != nil {
-		m.mtx.Unlock()
-		<-chRestoreDone
-		m.mtx.Lock()
-		if m.operation == opRestore {
-			m.endLocked()
-		}
+	if op != opRestore || chRestoreDone == nil {
+		return
 	}
+	<-chRestoreDone
+	m.mtx.Lock()
+	if m.operation == opRestore {
+		m.endLocked()
+	}
+	m.mtx.Unlock()
+}
 
+// waitOperationIdle blocks until no manager operation is in progress.
+func (m *Manager) waitOperationIdle() {
+	m.mtx.Lock()
 	for m.operation != opNone {
 		m.idle.Wait()
 	}
 	m.mtx.Unlock()
-
-	return m.store.db.Close()
 }

--- a/store/snapshots/manager.go
+++ b/store/snapshots/manager.go
@@ -46,17 +46,10 @@ type Manager struct {
 	operation         operation
 	closed            bool
 	abortCh           chan struct{}
-	activeWriter      *StreamWriter
 	chRestore         chan<- uint32
 	chRestoreDone     <-chan restoreDone
 	restoreSnapshot   *types.Snapshot
 	restoreChunkIndex uint32
-}
-
-// snapshotAbortAware is optionally implemented by snapshotters that can honor
-// manager shutdown without relying on snapshot stream write failures.
-type snapshotAbortAware interface {
-	SetSnapshotAbortCh(abort <-chan struct{})
 }
 
 // operation represents a Manager operation. Only one operation can be in progress at a time.
@@ -100,9 +93,6 @@ func NewManager(store *Store, opts types.SnapshotOptions, multistore types.Snaps
 		abortCh:    make(chan struct{}),
 	}
 	m.idle = sync.NewCond(&m.mtx)
-	if a, ok := multistore.(snapshotAbortAware); ok {
-		a.SetSnapshotAbortCh(m.abortCh)
-	}
 	return m
 }
 
@@ -219,25 +209,11 @@ func (m *Manager) Create(height uint64) (*types.Snapshot, error) {
 			"a more recent snapshot already exists at height %v", latest.Height)
 	}
 
-	// Spawn goroutine to generate snapshot chunks and pass their io.ReadClosers through a channel.
-	// Wait for it to finish before returning so Close can safely proceed only after
-	// export goroutines have stopped touching application state.
+	// Spawn goroutine to generate snapshot chunks and pass their io.ReadClosers through a channel
 	ch := make(chan io.ReadCloser)
-	var snapshotWG sync.WaitGroup
-	snapshotWG.Add(1)
-	go func() {
-		defer snapshotWG.Done()
-		m.createSnapshot(height, ch)
-	}()
+	go m.createSnapshot(height, ch)
 
-	snapshot, err := m.store.Save(height, types.CurrentFormat, ch)
-	snapshotWG.Wait()
-	// Prefer ErrAborted once the manager is closing so callers (e.g. SnapshotIfApplicable)
-	// treat shutdown cancellation distinctly from snapshot failures.
-	if m.isClosed() {
-		return nil, ErrAborted
-	}
-	return snapshot, err
+	return m.store.Save(height, types.CurrentFormat, ch)
 }
 
 // createSnapshot do the heavy work of snapshotting after the validations of request are done
@@ -247,34 +223,23 @@ func (m *Manager) createSnapshot(height uint64, ch chan<- io.ReadCloser) {
 	if streamWriter == nil {
 		return
 	}
-
-	m.mtx.Lock()
-	if m.closed {
-		m.mtx.Unlock()
-		streamWriter.CloseWithError(ErrAborted)
-		return
-	}
-	m.activeWriter = streamWriter
-	abortCh := m.abortCh
-	// Wake Close if it is waiting for the writer to be registered.
-	m.idle.Broadcast()
-	m.mtx.Unlock()
-
 	defer func() {
-		m.mtx.Lock()
-		if m.activeWriter == streamWriter {
-			m.activeWriter = nil
-		}
-		m.idle.Broadcast()
-		m.mtx.Unlock()
-
 		if err := streamWriter.Close(); err != nil {
 			streamWriter.CloseWithError(err)
 		}
 	}()
 
-	// Honor manager abort on every WriteMsg so Close does not wait for zlib/bufio
-	// buffers (snapshotBufferSize) to fill before ChunkWriter observes the close.
+	m.mtx.Lock()
+	closed := m.closed
+	abortCh := m.abortCh
+	m.mtx.Unlock()
+	if closed {
+		streamWriter.CloseWithError(ErrAborted)
+		return
+	}
+
+	// Honor manager abort on every WriteMsg so Close need not wait for zlib/bufio
+	// buffers (snapshotBufferSize) to fill before the export observes shutdown.
 	out := &abortAwareWriter{StreamWriter: streamWriter, abortCh: abortCh}
 
 	if err := m.multistore.Snapshot(height, out); err != nil {
@@ -661,7 +626,8 @@ func (m *Manager) snapshot(height int64) {
 // application state, then closes the snapshot metadata database.
 //
 // Close does not wait for a snapshot to finish being created; it cancels in-flight
-// work and only waits for that work to unwind.
+// work and only waits for that work to unwind. Abort is observed on the next
+// WriteMsg after any in-flight chunk write is consumed by Save.
 func (m *Manager) Close() error {
 	if m == nil {
 		return nil
@@ -680,45 +646,25 @@ func (m *Manager) Close() error {
 	op := m.operation
 	// Avoid double-close if RestoreChunk already closed the channel.
 	m.chRestore = nil
-	m.mtx.Unlock()
 
 	if chRestore != nil {
+		m.mtx.Unlock()
 		close(chRestore)
+		m.mtx.Lock()
 	}
 	if op == opRestore && chRestoreDone != nil {
+		m.mtx.Unlock()
 		<-chRestoreDone
 		m.mtx.Lock()
 		if m.operation == opRestore {
 			m.endLocked()
 		}
-		m.mtx.Unlock()
 	}
 
-	// Abort any active snapshot writer. Loop until idle so we cannot miss a writer that
-	// registers after we sample activeWriter as nil (createSnapshot race).
-	for {
-		m.mtx.Lock()
-		for m.operation != opNone && m.activeWriter == nil {
-			// Create has begun but createSnapshot has not registered the writer yet.
-			m.idle.Wait()
-		}
-		writer := m.activeWriter
-		idle := m.operation == opNone
-		m.mtx.Unlock()
-
-		if writer != nil {
-			writer.CloseWithError(ErrAborted)
-		}
-		if idle {
-			break
-		}
-
-		m.mtx.Lock()
-		for m.operation != opNone && m.activeWriter == writer {
-			m.idle.Wait()
-		}
-		m.mtx.Unlock()
+	for m.operation != opNone {
+		m.idle.Wait()
 	}
+	m.mtx.Unlock()
 
 	return m.store.db.Close()
 }

--- a/store/snapshots/manager.go
+++ b/store/snapshots/manager.go
@@ -11,6 +11,8 @@ import (
 	"sort"
 	"sync"
 
+	"github.com/cosmos/gogoproto/proto"
+
 	errorsmod "cosmossdk.io/errors"
 	"cosmossdk.io/log"
 	"cosmossdk.io/store/snapshots/types"
@@ -40,11 +42,21 @@ type Manager struct {
 	logger     log.Logger
 
 	mtx               sync.Mutex
+	idle              *sync.Cond
 	operation         operation
+	closed            bool
+	abortCh           chan struct{}
+	activeWriter      *StreamWriter
 	chRestore         chan<- uint32
 	chRestoreDone     <-chan restoreDone
 	restoreSnapshot   *types.Snapshot
 	restoreChunkIndex uint32
+}
+
+// snapshotAbortAware is optionally implemented by snapshotters that can honor
+// manager shutdown without relying on snapshot stream write failures.
+type snapshotAbortAware interface {
+	SetSnapshotAbortCh(abort <-chan struct{})
 }
 
 // operation represents a Manager operation. Only one operation can be in progress at a time.
@@ -68,20 +80,30 @@ const (
 	snapshotMaxItemSize = int(64e6) // SDK has no key/value size limit, so we set an arbitrary limit
 )
 
-var ErrOptsZeroSnapshotInterval = errors.New("snaphot-interval must not be 0")
+var (
+	ErrOptsZeroSnapshotInterval = errors.New("snaphot-interval must not be 0")
+	// ErrAborted is returned when a snapshot operation is canceled because the manager is closing.
+	ErrAborted = errors.New("snapshot aborted")
+)
 
 // NewManager creates a new manager.
 func NewManager(store *Store, opts types.SnapshotOptions, multistore types.Snapshotter, extensions map[string]types.ExtensionSnapshotter, logger log.Logger) *Manager {
 	if extensions == nil {
 		extensions = map[string]types.ExtensionSnapshotter{}
 	}
-	return &Manager{
+	m := &Manager{
 		store:      store,
 		opts:       opts,
 		multistore: multistore,
 		extensions: extensions,
 		logger:     logger,
+		abortCh:    make(chan struct{}),
 	}
+	m.idle = sync.NewCond(&m.mtx)
+	if a, ok := multistore.(snapshotAbortAware); ok {
+		a.SetSnapshotAbortCh(m.abortCh)
+	}
+	return m
 }
 
 // RegisterExtensions register extension snapshotters to manager
@@ -114,6 +136,9 @@ func (m *Manager) beginLocked(op operation) error {
 	if op == opNone {
 		return errorsmod.Wrap(storetypes.ErrLogic, "can't begin a none operation")
 	}
+	if m.closed {
+		return errorsmod.Wrap(ErrAborted, "snapshot manager is closed")
+	}
 	if m.operation != opNone {
 		return errorsmod.Wrapf(storetypes.ErrConflict, "a %v operation is in progress", m.operation)
 	}
@@ -138,6 +163,13 @@ func (m *Manager) endLocked() {
 	m.chRestoreDone = nil
 	m.restoreSnapshot = nil
 	m.restoreChunkIndex = 0
+	m.idle.Broadcast()
+}
+
+func (m *Manager) isClosed() bool {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+	return m.closed
 }
 
 // GetInterval returns snapshot interval represented in heights.
@@ -164,7 +196,13 @@ func (m *Manager) Create(height uint64) (*types.Snapshot, error) {
 		return nil, errorsmod.Wrap(storetypes.ErrLogic, "no snapshot store configured")
 	}
 
-	defer m.multistore.PruneSnapshotHeight(int64(height))
+	// PruneSnapshotHeight runs for both success and failure paths (historical behavior),
+	// but is skipped when the manager is closing to avoid writes against a closing app DB.
+	defer func() {
+		if !m.isClosed() {
+			m.multistore.PruneSnapshotHeight(int64(height))
+		}
+	}()
 
 	err := m.begin(opSnapshot)
 	if err != nil {
@@ -181,11 +219,25 @@ func (m *Manager) Create(height uint64) (*types.Snapshot, error) {
 			"a more recent snapshot already exists at height %v", latest.Height)
 	}
 
-	// Spawn goroutine to generate snapshot chunks and pass their io.ReadClosers through a channel
+	// Spawn goroutine to generate snapshot chunks and pass their io.ReadClosers through a channel.
+	// Wait for it to finish before returning so Close can safely proceed only after
+	// export goroutines have stopped touching application state.
 	ch := make(chan io.ReadCloser)
-	go m.createSnapshot(height, ch)
+	var snapshotWG sync.WaitGroup
+	snapshotWG.Add(1)
+	go func() {
+		defer snapshotWG.Done()
+		m.createSnapshot(height, ch)
+	}()
 
-	return m.store.Save(height, types.CurrentFormat, ch)
+	snapshot, err := m.store.Save(height, types.CurrentFormat, ch)
+	snapshotWG.Wait()
+	// Prefer ErrAborted once the manager is closing so callers (e.g. SnapshotIfApplicable)
+	// treat shutdown cancellation distinctly from snapshot failures.
+	if m.isClosed() {
+		return nil, ErrAborted
+	}
+	return snapshot, err
 }
 
 // createSnapshot do the heavy work of snapshotting after the validations of request are done
@@ -195,20 +247,44 @@ func (m *Manager) createSnapshot(height uint64, ch chan<- io.ReadCloser) {
 	if streamWriter == nil {
 		return
 	}
+
+	m.mtx.Lock()
+	if m.closed {
+		m.mtx.Unlock()
+		streamWriter.CloseWithError(ErrAborted)
+		return
+	}
+	m.activeWriter = streamWriter
+	abortCh := m.abortCh
+	// Wake Close if it is waiting for the writer to be registered.
+	m.idle.Broadcast()
+	m.mtx.Unlock()
+
 	defer func() {
+		m.mtx.Lock()
+		if m.activeWriter == streamWriter {
+			m.activeWriter = nil
+		}
+		m.idle.Broadcast()
+		m.mtx.Unlock()
+
 		if err := streamWriter.Close(); err != nil {
 			streamWriter.CloseWithError(err)
 		}
 	}()
 
-	if err := m.multistore.Snapshot(height, streamWriter); err != nil {
+	// Honor manager abort on every WriteMsg so Close does not wait for zlib/bufio
+	// buffers (snapshotBufferSize) to fill before ChunkWriter observes the close.
+	out := &abortAwareWriter{StreamWriter: streamWriter, abortCh: abortCh}
+
+	if err := m.multistore.Snapshot(height, out); err != nil {
 		streamWriter.CloseWithError(err)
 		return
 	}
 	for _, name := range m.sortedExtensionNames() {
 		extension := m.extensions[name]
 		// write extension metadata
-		err := streamWriter.WriteMsg(&types.SnapshotItem{
+		err := out.WriteMsg(&types.SnapshotItem{
 			Item: &types.SnapshotItem_Extension{
 				Extension: &types.SnapshotExtensionMeta{
 					Name:   name,
@@ -221,13 +297,29 @@ func (m *Manager) createSnapshot(height uint64, ch chan<- io.ReadCloser) {
 			return
 		}
 		payloadWriter := func(payload []byte) error {
-			return types.WriteExtensionPayload(streamWriter, payload)
+			return types.WriteExtensionPayload(out, payload)
 		}
 		if err := extension.SnapshotExtension(height, payloadWriter); err != nil {
 			streamWriter.CloseWithError(err)
 			return
 		}
 	}
+}
+
+// abortAwareWriter fails WriteMsg immediately once the manager abort channel is closed,
+// without waiting for compression buffers to flush into ChunkWriter.
+type abortAwareWriter struct {
+	*StreamWriter
+	abortCh <-chan struct{}
+}
+
+func (w *abortAwareWriter) WriteMsg(msg proto.Message) error {
+	select {
+	case <-w.abortCh:
+		return ErrAborted
+	default:
+	}
+	return w.StreamWriter.WriteMsg(msg)
 }
 
 // List lists snapshots, mirroring ABCI ListSnapshots. It can be concurrent with other operations.
@@ -401,8 +493,14 @@ func (m *Manager) doRestoreSnapshot(snapshot types.Snapshot, chChunks <-chan io.
 func (m *Manager) RestoreChunk(chunk []byte) (bool, error) {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
+	if m.closed {
+		return false, errorsmod.Wrap(ErrAborted, "snapshot manager is closed")
+	}
 	if m.operation != opRestore {
 		return false, errorsmod.Wrap(storetypes.ErrLogic, "no restore operation in progress")
+	}
+	if m.chRestore == nil {
+		return false, errorsmod.Wrap(ErrAborted, "snapshot restore was aborted")
 	}
 
 	if int(m.restoreChunkIndex) >= len(m.restoreSnapshot.Metadata.ChunkHashes) {
@@ -510,6 +608,9 @@ func (m *Manager) SnapshotIfApplicable(height int64) {
 	if m == nil {
 		return
 	}
+	if m.isClosed() {
+		return
+	}
 	if !m.shouldTakeSnapshot(height) {
 		m.logger.Debug("snapshot is skipped", "height", height)
 		return
@@ -533,6 +634,10 @@ func (m *Manager) snapshot(height int64) {
 
 	snapshot, err := m.Create(uint64(height))
 	if err != nil {
+		if errors.Is(err, ErrAborted) || m.isClosed() {
+			m.logger.Info("state snapshot aborted", "height", height, "err", err)
+			return
+		}
 		m.logger.Error("failed to create state snapshot", "height", height, "err", err)
 		return
 	}
@@ -552,7 +657,68 @@ func (m *Manager) snapshot(height int64) {
 	}
 }
 
-// Close the snapshot database.
+// Close aborts any in-flight snapshot/restore work, waits for it to stop touching
+// application state, then closes the snapshot metadata database.
+//
+// Close does not wait for a snapshot to finish being created; it cancels in-flight
+// work and only waits for that work to unwind.
 func (m *Manager) Close() error {
+	if m == nil {
+		return nil
+	}
+
+	m.mtx.Lock()
+	if m.closed {
+		m.mtx.Unlock()
+		return nil
+	}
+	m.closed = true
+	close(m.abortCh)
+
+	chRestore := m.chRestore
+	chRestoreDone := m.chRestoreDone
+	op := m.operation
+	// Avoid double-close if RestoreChunk already closed the channel.
+	m.chRestore = nil
+	m.mtx.Unlock()
+
+	if chRestore != nil {
+		close(chRestore)
+	}
+	if op == opRestore && chRestoreDone != nil {
+		<-chRestoreDone
+		m.mtx.Lock()
+		if m.operation == opRestore {
+			m.endLocked()
+		}
+		m.mtx.Unlock()
+	}
+
+	// Abort any active snapshot writer. Loop until idle so we cannot miss a writer that
+	// registers after we sample activeWriter as nil (createSnapshot race).
+	for {
+		m.mtx.Lock()
+		for m.operation != opNone && m.activeWriter == nil {
+			// Create has begun but createSnapshot has not registered the writer yet.
+			m.idle.Wait()
+		}
+		writer := m.activeWriter
+		idle := m.operation == opNone
+		m.mtx.Unlock()
+
+		if writer != nil {
+			writer.CloseWithError(ErrAborted)
+		}
+		if idle {
+			break
+		}
+
+		m.mtx.Lock()
+		for m.operation != opNone && m.activeWriter == writer {
+			m.idle.Wait()
+		}
+		m.mtx.Unlock()
+	}
+
 	return m.store.db.Close()
 }

--- a/store/snapshots/manager_test.go
+++ b/store/snapshots/manager_test.go
@@ -2,6 +2,8 @@ package snapshots_test
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -264,6 +266,184 @@ func TestManager_CloseIdempotent(t *testing.T) {
 	manager := snapshots.NewManager(store, opts, &mockSnapshotter{}, nil, log.NewNopLogger())
 	require.NoError(t, manager.Close())
 	require.NoError(t, manager.Close())
+}
+
+// TestManager_CloseAbortsPreWriteBlockingSnapshotter covers shutdown while Snapshot
+// is blocked before any WriteMsg. The snapshotter observes abortCh (injected by
+// NewManager) and returns, so Close does not hang.
+func TestManager_CloseAbortsPreWriteBlockingSnapshotter(t *testing.T) {
+	store, err := snapshots.NewStore(db.NewMemDB(), t.TempDir())
+	require.NoError(t, err)
+
+	blocker := &preWriteBlockingSnapshotter{entered: make(chan struct{})}
+	manager := snapshots.NewManager(store, opts, blocker, nil, log.NewNopLogger())
+	require.NotNil(t, blocker.abort, "NewManager must inject abort channel")
+
+	createErr := make(chan error, 1)
+	go func() {
+		_, err := manager.Create(1)
+		createErr <- err
+	}()
+
+	select {
+	case <-blocker.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for Snapshot to block before WriteMsg")
+	}
+
+	require.NoError(t, manager.Close())
+
+	select {
+	case err := <-createErr:
+		require.ErrorIs(t, err, snapshots.ErrAborted)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for Create to abort — pre-write block did not observe abortCh")
+	}
+}
+
+// preWriteBlockingSnapshotter blocks before WriteMsg until the manager abort channel
+// is closed (SetSnapshotAbortCh).
+type preWriteBlockingSnapshotter struct {
+	entered chan struct{}
+	abort   <-chan struct{}
+}
+
+func (p *preWriteBlockingSnapshotter) SetSnapshotAbortCh(abort <-chan struct{}) {
+	p.abort = abort
+}
+
+func (p *preWriteBlockingSnapshotter) Snapshot(height uint64, protoWriter protoio.Writer) error {
+	close(p.entered)
+	<-p.abort
+	return snapshots.ErrAborted
+}
+
+func (p *preWriteBlockingSnapshotter) PruneSnapshotHeight(height int64)            {}
+func (p *preWriteBlockingSnapshotter) SetSnapshotInterval(snapshotInterval uint64) {}
+func (p *preWriteBlockingSnapshotter) Restore(height uint64, format uint32, protoReader protoio.Reader) (types.SnapshotItem, error) {
+	panic("not implemented")
+}
+
+// TestManager_ConcurrentCloseWaitsForCompletion ensures a second Close does not
+// return while the first is still waiting for in-flight snapshot work. Both
+// callers share completion and receive the same result.
+func TestManager_ConcurrentCloseWaitsForCompletion(t *testing.T) {
+	store, err := snapshots.NewStore(db.NewMemDB(), t.TempDir())
+	require.NoError(t, err)
+
+	gate := &gatedSnapshotter{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	manager := snapshots.NewManager(store, opts, gate, nil, log.NewNopLogger())
+
+	createErr := make(chan error, 1)
+	go func() {
+		_, err := manager.Create(1)
+		createErr <- err
+	}()
+
+	select {
+	case <-gate.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for Snapshot to start")
+	}
+
+	closeErr1 := make(chan error, 1)
+	closeErr2 := make(chan error, 1)
+	go func() { closeErr1 <- manager.Close() }()
+	go func() { closeErr2 <- manager.Close() }()
+
+	// While Snapshot is still blocked, neither Close may return.
+	time.Sleep(100 * time.Millisecond)
+	select {
+	case err := <-closeErr1:
+		t.Fatalf("first Close returned early while snapshot still running: %v", err)
+	default:
+	}
+	select {
+	case err := <-closeErr2:
+		t.Fatalf("second Close returned early while snapshot still running: %v", err)
+	default:
+	}
+
+	close(gate.release)
+
+	select {
+	case err := <-closeErr1:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for first Close")
+	}
+	select {
+	case err := <-closeErr2:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for second Close")
+	}
+
+	select {
+	case err := <-createErr:
+		require.Error(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for Create after Close")
+	}
+}
+
+// gatedSnapshotter blocks in Snapshot until release is closed, without WriteMsg.
+// Used to hold an opSnapshot open while testing concurrent Close.
+type gatedSnapshotter struct {
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (g *gatedSnapshotter) Snapshot(height uint64, protoWriter protoio.Writer) error {
+	close(g.entered)
+	<-g.release
+	return snapshots.ErrAborted
+}
+func (g *gatedSnapshotter) PruneSnapshotHeight(height int64)            {}
+func (g *gatedSnapshotter) SetSnapshotInterval(snapshotInterval uint64) {}
+func (g *gatedSnapshotter) Restore(height uint64, format uint32, protoReader protoio.Reader) (types.SnapshotItem, error) {
+	panic("not implemented")
+}
+
+// TestManager_CloseAfterRestoreSetupFailure ensures Restore rolls back opRestore when
+// snapshot directory creation fails, so Close does not hang waiting for opNone.
+func TestManager_CloseAfterRestoreSetupFailure(t *testing.T) {
+	dir := t.TempDir()
+	store, err := snapshots.NewStore(db.NewMemDB(), dir)
+	require.NoError(t, err)
+	manager := snapshots.NewManager(store, opts, &mockSnapshotter{prunedHeights: map[int64]struct{}{}}, nil, log.NewNopLogger())
+
+	// pathSnapshot is dir/<height>/<format>; place a file at dir/<height> so MkdirAll fails.
+	height := uint64(3)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "3"), []byte("not-a-directory"), 0o600))
+
+	err = manager.Restore(types.Snapshot{
+		Height:   height,
+		Format:   types.CurrentFormat,
+		Hash:     []byte{1},
+		Chunks:   1,
+		Metadata: types.Metadata{ChunkHashes: [][]byte{{1}}},
+	})
+	require.Error(t, err)
+
+	// A subsequent operation must be allowed (opRestore was rolled back).
+	_, err = manager.Prune(1)
+	require.NoError(t, err)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- manager.Close()
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close hung after Restore setup failure — opRestore likely not rolled back")
+	}
 }
 
 // writingSnapshotter keeps writing until the stream writer fails (e.g. aborted by Close).

--- a/store/snapshots/manager_test.go
+++ b/store/snapshots/manager_test.go
@@ -2,9 +2,12 @@ package snapshots_test
 
 import (
 	"errors"
+	"sync"
 	"testing"
+	"time"
 
 	db "github.com/cosmos/cosmos-db"
+	protoio "github.com/cosmos/gogoproto/io"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -255,4 +258,106 @@ func TestManager_TakeError(t *testing.T) {
 
 	_, err = manager.Create(1)
 	require.Error(t, err)
+}
+
+func TestManager_CloseAbortsInFlightSnapshot(t *testing.T) {
+	store, err := snapshots.NewStore(db.NewMemDB(), t.TempDir())
+	require.NoError(t, err)
+
+	hung := newHungSnapshotter()
+	hung.SetSnapshotInterval(opts.Interval)
+	manager := snapshots.NewManager(store, opts, hung, nil, log.NewNopLogger())
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := manager.Create(1)
+		errCh <- err
+	}()
+
+	select {
+	case <-hung.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for Snapshot to start")
+	}
+
+	require.NoError(t, manager.Close())
+
+	select {
+	case err := <-errCh:
+		require.ErrorIs(t, err, snapshots.ErrAborted)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for Create to abort")
+	}
+
+	_, didPruneHeight := hung.prunedHeights[1]
+	require.False(t, didPruneHeight, "aborted snapshots should not prune snapshot heights")
+
+	// Further snapshot attempts should fail fast.
+	_, err = manager.Create(2)
+	require.ErrorIs(t, err, snapshots.ErrAborted)
+
+	manager.SnapshotIfApplicable(int64(opts.Interval)) // must not panic or hang
+}
+
+func TestManager_CloseIdempotent(t *testing.T) {
+	store, err := snapshots.NewStore(db.NewMemDB(), t.TempDir())
+	require.NoError(t, err)
+	manager := snapshots.NewManager(store, opts, &mockSnapshotter{}, nil, log.NewNopLogger())
+	require.NoError(t, manager.Close())
+	require.NoError(t, manager.Close())
+}
+
+// writingSnapshotter keeps writing until the stream writer fails (e.g. aborted by Close).
+type writingSnapshotter struct {
+	started chan struct{}
+	once    sync.Once
+}
+
+func (w *writingSnapshotter) Snapshot(height uint64, protoWriter protoio.Writer) error {
+	w.once.Do(func() { close(w.started) })
+	for {
+		err := protoWriter.WriteMsg(&types.SnapshotItem{
+			Item: &types.SnapshotItem_Store{
+				Store: &types.SnapshotStoreItem{Name: "busy"},
+			},
+		})
+		if err != nil {
+			return err
+		}
+	}
+}
+
+func (w *writingSnapshotter) PruneSnapshotHeight(height int64)            {}
+func (w *writingSnapshotter) SetSnapshotInterval(snapshotInterval uint64) {}
+func (w *writingSnapshotter) Restore(height uint64, format uint32, protoReader protoio.Reader) (types.SnapshotItem, error) {
+	panic("not implemented")
+}
+
+func TestManager_CloseAbortsWritingSnapshot(t *testing.T) {
+	store, err := snapshots.NewStore(db.NewMemDB(), t.TempDir())
+	require.NoError(t, err)
+
+	writer := &writingSnapshotter{started: make(chan struct{})}
+	manager := snapshots.NewManager(store, opts, writer, nil, log.NewNopLogger())
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := manager.Create(1)
+		errCh <- err
+	}()
+
+	select {
+	case <-writer.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for writing snapshot to start")
+	}
+
+	require.NoError(t, manager.Close())
+
+	select {
+	case err := <-errCh:
+		require.ErrorIs(t, err, snapshots.ErrAborted)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for Create to abort")
+	}
 }

--- a/store/snapshots/manager_test.go
+++ b/store/snapshots/manager_test.go
@@ -38,8 +38,6 @@ func TestManager_List(t *testing.T) {
 	list, err := manager.List()
 	require.NoError(t, err)
 	assert.Equal(t, []*types.Snapshot{}, list)
-
-	require.NoError(t, manager.Close())
 }
 
 func TestManager_LoadChunk(t *testing.T) {
@@ -260,45 +258,6 @@ func TestManager_TakeError(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestManager_CloseAbortsInFlightSnapshot(t *testing.T) {
-	store, err := snapshots.NewStore(db.NewMemDB(), t.TempDir())
-	require.NoError(t, err)
-
-	hung := newHungSnapshotter()
-	hung.SetSnapshotInterval(opts.Interval)
-	manager := snapshots.NewManager(store, opts, hung, nil, log.NewNopLogger())
-
-	errCh := make(chan error, 1)
-	go func() {
-		_, err := manager.Create(1)
-		errCh <- err
-	}()
-
-	select {
-	case <-hung.entered:
-	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for Snapshot to start")
-	}
-
-	require.NoError(t, manager.Close())
-
-	select {
-	case err := <-errCh:
-		require.ErrorIs(t, err, snapshots.ErrAborted)
-	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for Create to abort")
-	}
-
-	_, didPruneHeight := hung.prunedHeights[1]
-	require.False(t, didPruneHeight, "aborted snapshots should not prune snapshot heights")
-
-	// Further snapshot attempts should fail fast.
-	_, err = manager.Create(2)
-	require.ErrorIs(t, err, snapshots.ErrAborted)
-
-	manager.SnapshotIfApplicable(int64(opts.Interval)) // must not panic or hang
-}
-
 func TestManager_CloseIdempotent(t *testing.T) {
 	store, err := snapshots.NewStore(db.NewMemDB(), t.TempDir())
 	require.NoError(t, err)
@@ -309,8 +268,9 @@ func TestManager_CloseIdempotent(t *testing.T) {
 
 // writingSnapshotter keeps writing until the stream writer fails (e.g. aborted by Close).
 type writingSnapshotter struct {
-	started chan struct{}
-	once    sync.Once
+	started       chan struct{}
+	once          sync.Once
+	prunedHeights map[int64]struct{}
 }
 
 func (w *writingSnapshotter) Snapshot(height uint64, protoWriter protoio.Writer) error {
@@ -327,7 +287,12 @@ func (w *writingSnapshotter) Snapshot(height uint64, protoWriter protoio.Writer)
 	}
 }
 
-func (w *writingSnapshotter) PruneSnapshotHeight(height int64)            {}
+func (w *writingSnapshotter) PruneSnapshotHeight(height int64) {
+	if w.prunedHeights == nil {
+		w.prunedHeights = make(map[int64]struct{})
+	}
+	w.prunedHeights[height] = struct{}{}
+}
 func (w *writingSnapshotter) SetSnapshotInterval(snapshotInterval uint64) {}
 func (w *writingSnapshotter) Restore(height uint64, format uint32, protoReader protoio.Reader) (types.SnapshotItem, error) {
 	panic("not implemented")
@@ -337,7 +302,10 @@ func TestManager_CloseAbortsWritingSnapshot(t *testing.T) {
 	store, err := snapshots.NewStore(db.NewMemDB(), t.TempDir())
 	require.NoError(t, err)
 
-	writer := &writingSnapshotter{started: make(chan struct{})}
+	writer := &writingSnapshotter{
+		started:       make(chan struct{}),
+		prunedHeights: make(map[int64]struct{}),
+	}
 	manager := snapshots.NewManager(store, opts, writer, nil, log.NewNopLogger())
 
 	errCh := make(chan error, 1)
@@ -360,4 +328,13 @@ func TestManager_CloseAbortsWritingSnapshot(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for Create to abort")
 	}
+
+	_, didPruneHeight := writer.prunedHeights[1]
+	require.False(t, didPruneHeight, "aborted snapshots should not prune snapshot heights")
+
+	// Further snapshot attempts should fail fast.
+	_, err = manager.Create(2)
+	require.ErrorIs(t, err, snapshots.ErrAborted)
+
+	manager.SnapshotIfApplicable(int64(opts.Interval)) // must not panic or hang
 }

--- a/store/snapshots/types/errors.go
+++ b/store/snapshots/types/errors.go
@@ -16,4 +16,7 @@ var (
 
 	// ErrInvalidSnapshotVersion is returned when the snapshot version is invalid
 	ErrInvalidSnapshotVersion = errors.New("invalid snapshot version")
+
+	// ErrAborted is returned when a snapshot operation is canceled because the manager is closing.
+	ErrAborted = errors.New("snapshot aborted")
 )


### PR DESCRIPTION
## Summary
- Fixes [celestia-app#7252](https://github.com/celestiaorg/celestia-app/issues/7252): shutdown panic (`leveldb: closed` / `pebble: closed`) when a state-sync snapshot is in flight.
- Root cause: `SnapshotIfApplicable` runs async; `BaseApp.Close` closed `application.db` before aborting that work; `HandleSnapshotHeight` panics on `SetSync` errors.
- Changes:
  - Close snapshot manager **before** `application.db`
  - `Manager.Close` aborts in-flight export/restore and waits for unwind (does not wait for a full snapshot to finish)
  - Skip `PruneSnapshotHeight` while closing; log DB write errors in `HandleSnapshotHeight` instead of panicking
  - Make `ChunkWriter` safe for concurrent `Write` vs `CloseWithError`; abort promptly via `abortAwareWriter`

## Test plan
- [x] `go test ./baseapp/ -run TestBaseApp_Close_`
- [x] `go test ./store/snapshots/ ./store/pruning/ ./store/rootmulti/ -run 'Close|HandleSnapshotHeight_DbErr|ManagerCloseAborts'`
- [x] Local A/B against celestia-app with `replace` to this branch vs published `v0.52.8` / `store@v1.1.3-celestia.1`: unfixed reproduces `panic: leveldb/pebble: closed` via `HandleSnapshotHeight`; this branch does not
## Notes
Matches intended shutdown behavior: cancel in-flight snapshot work on stop, without waiting for snapshot creation to complete.