### PR TITLE
docs: instruct Claude to write short godoc comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,10 @@ In `go.mod`, CometBFT is replaced with celestia-core:
 github.com/cometbft/cometbft => github.com/celestiaorg/celestia-core v0.39.11
 ```
 
+## Code Conventions
+
+- Keep godoc comments short and easy to understand: one or two plain-language sentences saying what the thing does. Avoid big blocks of text — they are hard to read and reason about.
+
 ## Security PRs
 
 - For PRs that resolve Hacken bug bounty reports, do not include details about the bug in the PR description. Instead, link to a Linear issue that contains more details on the bug and the link to the Hacken bug bounty report.


### PR DESCRIPTION
Adds a Code Conventions bullet to CLAUDE.md telling Claude to write short, plain-language godoc comments instead of big blocks of text. Same convention as celestiaorg/celestia-core#3246 and celestiaorg/celestia-app#7713.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015i7TBLnRkyYgAEGJx17Yp6