### PR TITLE
fix(x/evidence)!: ignore equivocation evidence for a deleted validator

### DIFF
--- a/x/evidence/CHANGELOG.md
+++ b/x/evidence/CHANGELOG.md
@@ -27,7 +27,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
-* (keeper) [#749](https://github.com/celestiaorg/cosmos-sdk/pull/749) Ignore equivocation evidence for a validator whose record no longer exists instead of returning an error that halts the chain.
+* (keeper) [#749](https://github.com/celestiaorg/cosmos-sdk/pull/749) Ignore equivocation evidence for a validator whose record no longer exists instead of returning an error.
 
 ## [v0.1.1](https://github.com/cosmos/cosmos-sdk/releases/tag/x/evidence/v0.1.1) - 2024-04-22
 

--- a/x/evidence/CHANGELOG.md
+++ b/x/evidence/CHANGELOG.md
@@ -23,6 +23,12 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Changelog
 
+## [Unreleased]
+
+### Bug Fixes
+
+* (keeper) [#749](https://github.com/celestiaorg/cosmos-sdk/pull/749) Ignore equivocation evidence for a validator whose record no longer exists instead of returning an error that halts the chain.
+
 ## [v0.1.1](https://github.com/cosmos/cosmos-sdk/releases/tag/x/evidence/v0.1.1) - 2024-04-22
 
 ### Improvements

--- a/x/evidence/CHANGELOG.md
+++ b/x/evidence/CHANGELOG.md
@@ -23,12 +23,6 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Changelog
 
-## [Unreleased]
-
-### Bug Fixes
-
-* (keeper) [#749](https://github.com/celestiaorg/cosmos-sdk/pull/749) Ignore equivocation evidence for a validator whose record no longer exists instead of returning an error.
-
 ## [v0.1.1](https://github.com/cosmos/cosmos-sdk/releases/tag/x/evidence/v0.1.1) - 2024-04-22
 
 ### Improvements

--- a/x/evidence/README.md
+++ b/x/evidence/README.md
@@ -240,7 +240,7 @@ should be slashed, even if it has since been redelegated or started unbonding.
 In addition, the validator is permanently jailed and tombstoned to make it impossible for that
 validator to ever re-enter the validator set.
 
-Evidence naming a validator whose record no longer exists in staking state (e.g. it fully unbonded and was removed) is ignored rather than returned as an error, which would halt the chain.
+Evidence naming a validator whose record no longer exists in staking state (e.g. it fully unbonded and was removed) is ignored.
 
 The `Equivocation` evidence is handled as follows:
 

--- a/x/evidence/README.md
+++ b/x/evidence/README.md
@@ -240,6 +240,8 @@ should be slashed, even if it has since been redelegated or started unbonding.
 In addition, the validator is permanently jailed and tombstoned to make it impossible for that
 validator to ever re-enter the validator set.
 
+Evidence naming a validator whose record no longer exists in staking state (e.g. it fully unbonded and was removed) is ignored rather than returned as an error, which would halt the chain.
+
 The `Equivocation` evidence is handled as follows:
 
 ```go reference

--- a/x/evidence/keeper/export_test.go
+++ b/x/evidence/keeper/export_test.go
@@ -1,0 +1,12 @@
+package keeper
+
+import (
+	"context"
+
+	"cosmossdk.io/x/evidence/types"
+)
+
+// HandleEquivocationEvidence exposes handleEquivocationEvidence for testing.
+func (k Keeper) HandleEquivocationEvidence(ctx context.Context, evidence *types.Equivocation) error {
+	return k.handleEquivocationEvidence(ctx, evidence)
+}

--- a/x/evidence/keeper/infraction.go
+++ b/x/evidence/keeper/infraction.go
@@ -34,7 +34,7 @@ func (k Keeper) handleEquivocationEvidence(ctx context.Context, evidence *types.
 	if err != nil {
 		if errors.Is(err, stakingtypes.ErrNoValidatorFound) {
 			// The validator's record was deleted (e.g. it fully unbonded).
-			// Ignore the evidence rather than halting the chain.
+			// Ignore the evidence.
 			logger.Error(fmt.Sprintf("ignore evidence; validator %s not found", consAddr))
 			return nil
 		}

--- a/x/evidence/keeper/infraction.go
+++ b/x/evidence/keeper/infraction.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"cosmossdk.io/x/evidence/types"
@@ -31,6 +32,12 @@ func (k Keeper) handleEquivocationEvidence(ctx context.Context, evidence *types.
 
 	validator, err := k.stakingKeeper.ValidatorByConsAddr(ctx, consAddr)
 	if err != nil {
+		if errors.Is(err, stakingtypes.ErrNoValidatorFound) {
+			// The validator's record was deleted (e.g. it fully unbonded).
+			// Ignore the evidence rather than halting the chain.
+			logger.Error(fmt.Sprintf("ignore evidence; validator %s not found", consAddr))
+			return nil
+		}
 		return err
 	}
 	if validator == nil || validator.IsUnbonded() {

--- a/x/evidence/keeper/infraction_test.go
+++ b/x/evidence/keeper/infraction_test.go
@@ -15,7 +15,7 @@ import (
 
 // TestHandleEquivocationEvidenceDeletedValidator verifies that evidence naming
 // a validator whose record no longer exists in staking state is ignored
-// instead of returning an error, which would halt the chain.
+// instead of returning an error.
 func (suite *KeeperTestSuite) TestHandleEquivocationEvidenceDeletedValidator() {
 	pk := ed25519.GenPrivKey()
 	evidence := &types.Equivocation{

--- a/x/evidence/keeper/infraction_test.go
+++ b/x/evidence/keeper/infraction_test.go
@@ -1,0 +1,35 @@
+package keeper_test
+
+import (
+	"time"
+
+	"github.com/golang/mock/gomock"
+
+	"cosmossdk.io/x/evidence/types"
+
+	"github.com/cosmos/cosmos-sdk/codec/address"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+)
+
+// TestHandleEquivocationEvidenceDeletedValidator verifies that evidence naming
+// a validator whose record no longer exists in staking state is ignored
+// instead of returning an error, which would halt the chain.
+func (suite *KeeperTestSuite) TestHandleEquivocationEvidenceDeletedValidator() {
+	pk := ed25519.GenPrivKey()
+	evidence := &types.Equivocation{
+		Height:           1,
+		Power:            100,
+		Time:             time.Now().UTC(),
+		ConsensusAddress: sdk.ConsAddress(pk.PubKey().Address().Bytes()).String(),
+	}
+
+	suite.stakingKeeper.EXPECT().ConsensusAddressCodec().Return(address.NewBech32Codec(sdk.Bech32PrefixConsAddr)).AnyTimes()
+	// The staking keeper returns a zero-value validator alongside
+	// ErrNoValidatorFound once the validator's record has been deleted.
+	suite.stakingKeeper.EXPECT().ValidatorByConsAddr(gomock.Any(), gomock.Any()).Return(stakingtypes.Validator{}, stakingtypes.ErrNoValidatorFound)
+
+	err := suite.evidenceKeeper.HandleEquivocationEvidence(suite.ctx, evidence)
+	suite.Require().NoError(err)
+}

--- a/x/evidence/keeper/infraction_test.go
+++ b/x/evidence/keeper/infraction_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	"errors"
 	"time"
 
 	"github.com/golang/mock/gomock"
@@ -32,4 +33,22 @@ func (suite *KeeperTestSuite) TestHandleEquivocationEvidenceDeletedValidator() {
 
 	err := suite.evidenceKeeper.HandleEquivocationEvidence(suite.ctx, evidence)
 	suite.Require().NoError(err)
+}
+
+// TestHandleEquivocationEvidenceStakingError verifies that errors other than
+// ErrNoValidatorFound from the staking keeper still propagate.
+func (suite *KeeperTestSuite) TestHandleEquivocationEvidenceStakingError() {
+	pk := ed25519.GenPrivKey()
+	evidence := &types.Equivocation{
+		Height:           1,
+		Power:            100,
+		Time:             time.Now().UTC(),
+		ConsensusAddress: sdk.ConsAddress(pk.PubKey().Address().Bytes()).String(),
+	}
+
+	suite.stakingKeeper.EXPECT().ConsensusAddressCodec().Return(address.NewBech32Codec(sdk.Bech32PrefixConsAddr)).AnyTimes()
+	suite.stakingKeeper.EXPECT().ValidatorByConsAddr(gomock.Any(), gomock.Any()).Return(stakingtypes.Validator{}, errors.New("boom"))
+
+	err := suite.evidenceKeeper.HandleEquivocationEvidence(suite.ctx, evidence)
+	suite.Require().ErrorContains(err, "boom")
 }


### PR DESCRIPTION
Part of [PROTOCO-2361](https://linear.app/celestia/issue/PROTOCO-2361/handle-celestia-267-equivocation-evidence-for-a-deleted-validator).

Treats `ErrNoValidatorFound` from `ValidatorByConsAddr` the same as the handler's existing defensive nil-validator branch: the evidence is ignored instead of the error propagating out of `FinalizeBlock`.

To consume this in celestia-app, tag `x/evidence/v0.1.2-celestia` and add `replace cosmossdk.io/x/evidence => github.com/celestiaorg/cosmos-sdk/x/evidence v0.1.2-celestia` (same pattern as the `store` replace).

Note for reviewers: consensus-affecting — alternative to celestiaorg/celestia-app#7707, which patches the same behavior via a wrapper in celestia-app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)