### PR TITLE
ci: add mergify config to backport PRs via labels

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,33 @@
+pull_request_rules:
+  - name: backport patches to release/v0.46.x-celestia branch
+    conditions:
+      - label=backport:v0.46.x-celestia
+      - -base=release/v0.46.x-celestia
+    actions:
+      backport:
+        branches:
+          - release/v0.46.x-celestia
+  - name: backport patches to release/v0.50.x-celestia branch
+    conditions:
+      - label=backport:v0.50.x-celestia
+      - -base=release/v0.50.x-celestia
+    actions:
+      backport:
+        branches:
+          - release/v0.50.x-celestia
+  - name: backport patches to release/v0.51.x-celestia branch
+    conditions:
+      - label=backport:v0.51.x-celestia
+      - -base=release/v0.51.x-celestia
+    actions:
+      backport:
+        branches:
+          - release/v0.51.x-celestia
+  - name: backport patches to release/v0.52.x-celestia branch
+    conditions:
+      - label=backport:v0.52.x-celestia
+      - -base=release/v0.52.x-celestia
+    actions:
+      backport:
+        branches:
+          - release/v0.52.x-celestia

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,20 +20,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
-      - uses: technote-space/get-diff-action@v6.1.2
-        id: git_diff
-        with:
-          PATTERNS: |
-            **/*.go
-            go.mod
-            go.sum
-            **/go.mod
-            **/go.sum
-            Makefile
-            **/Makefile
-            .golangci.yml
       - name: golangci-lint
-        if: env.GIT_DIFF
         uses: golangci/golangci-lint-action@v6.1.0
         with:
           version: v1.61.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,20 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
+      - uses: technote-space/get-diff-action@v6.1.2
+        id: git_diff
+        with:
+          PATTERNS: |
+            **/*.go
+            go.mod
+            go.sum
+            **/go.mod
+            **/go.sum
+            Makefile
+            **/Makefile
+            .golangci.yml
       - name: golangci-lint
+        if: env.GIT_DIFF
         uses: golangci/golangci-lint-action@v6.1.0
         with:
           version: v1.61.0


### PR DESCRIPTION
Closes https://github.com/celestiaorg/cosmos-sdk/issues/665

Adds a Mergify config so a merged PR can be automatically backported to the maintained release branches (v0.46.x, v0.50.x, v0.51.x, v0.52.x -celestia) by applying the matching `backport:vX.Y.x-celestia` label. The labels have been created in the repo. Since this fork has no `main`, each rule guards against backporting a PR onto its own base branch instead of conditioning on `base=main`.

Note for reviewers: the Mergify GitHub App must be enabled for this repo for the config to take effect. The golangci-lint fix that briefly lived here moved to #755; lint on this PR will stay red until #755 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RmyRigDejhNr71pX76zjqz