### PR TITLE
ci: fix failing lint, docker build, and liveness workflows

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,33 @@
+pull_request_rules:
+  - name: backport patches to release/v0.46.x-celestia branch
+    conditions:
+      - label=backport:v0.46.x-celestia
+      - -base=release/v0.46.x-celestia
+    actions:
+      backport:
+        branches:
+          - release/v0.46.x-celestia
+  - name: backport patches to release/v0.50.x-celestia branch
+    conditions:
+      - label=backport:v0.50.x-celestia
+      - -base=release/v0.50.x-celestia
+    actions:
+      backport:
+        branches:
+          - release/v0.50.x-celestia
+  - name: backport patches to release/v0.51.x-celestia branch
+    conditions:
+      - label=backport:v0.51.x-celestia
+      - -base=release/v0.51.x-celestia
+    actions:
+      backport:
+        branches:
+          - release/v0.51.x-celestia
+  - name: backport patches to release/v0.52.x-celestia branch
+    conditions:
+      - label=backport:v0.52.x-celestia
+      - -base=release/v0.52.x-celestia
+    actions:
+      backport:
+        branches:
+          - release/v0.52.x-celestia

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,4 +36,4 @@ jobs:
         if: env.GIT_DIFF
         uses: golangci/golangci-lint-action@v6.1.0
         with:
-          version: v1.61.0
+          version: v1.64.8

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,20 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
+      - uses: technote-space/get-diff-action@v6.1.2
+        id: git_diff
+        with:
+          PATTERNS: |
+            **/*.go
+            go.mod
+            go.sum
+            **/go.mod
+            **/go.sum
+            Makefile
+            **/Makefile
+            .golangci.yml
       - name: golangci-lint
+        if: env.GIT_DIFF
         uses: golangci/golangci-lint-action@v6.1.0
         with:
           version: v1.61.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,7 +7,6 @@ linters:
   disable-all: true
   enable:
     - dogsled
-    - exportloopref
     - goconst
     - gocritic
     - gofumpt

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@
 # > docker run -it -p 26657:26657 -p 26656:26656 -v ~/.simappcli:/root/.simapp simapp simd keys add foo
 # > docker run -it -p 26657:26657 -p 26656:26656 -v ~/.simappcli:/root/.simapp simapp simd keys list
 # TODO: demo connecting rest-server (or is this in server now?)
-FROM golang:1.22.1-alpine AS build-env
+FROM golang:1.24-alpine AS build-env
 
 # Install minimum necessary dependencies
 ENV PACKAGES curl make git libc-dev bash gcc linux-headers eudev-dev python3

--- a/Makefile
+++ b/Makefile
@@ -460,10 +460,10 @@ localnet-build-dlv:
 localnet-build-nodes:
 	$(DOCKER) run --rm -v $(CURDIR)/.testnets:/data cosmossdk/simd \
 			  testnet init-files --v 4 -o /data --starting-ip-address 192.168.10.2 --keyring-backend=test
-	docker-compose up -d
+	docker compose up -d
 
 localnet-stop:
-	docker-compose down
+	docker compose down
 
 # localnet-start will run a 4-node testnet locally. The nodes are
 # based off the docker images in: ./contrib/images/simd-env

--- a/contrib/images/simd-dlv/Dockerfile
+++ b/contrib/images/simd-dlv/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.1-alpine AS build
+FROM golang:1.24-alpine AS build
 
 RUN apk add build-base git linux-headers libc-dev
 RUN go install github.com/go-delve/delve/cmd/dlv@latest

--- a/contrib/images/simd-env/Dockerfile
+++ b/contrib/images/simd-env/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.1-alpine AS build
+FROM golang:1.24-alpine AS build
 
 RUN apk add build-base git linux-headers
 

--- a/server/rosetta/converter.go
+++ b/server/rosetta/converter.go
@@ -338,8 +338,8 @@ func sdkEventToBalanceOperations(status string, event abci.Event) (operations []
 	default:
 		return nil, false
 	case banktypes.EventTypeCoinSpent:
-		spender := sdk.MustAccAddressFromBech32(string(event.Attributes[0].Value))
-		coins, err := sdk.ParseCoinsNormalized(string(event.Attributes[1].Value))
+		spender := sdk.MustAccAddressFromBech32(event.Attributes[0].Value)
+		coins, err := sdk.ParseCoinsNormalized(event.Attributes[1].Value)
 		if err != nil {
 			panic(err)
 		}
@@ -349,8 +349,8 @@ func sdkEventToBalanceOperations(status string, event abci.Event) (operations []
 		accountIdentifier = spender.String()
 
 	case banktypes.EventTypeCoinReceived:
-		receiver := sdk.MustAccAddressFromBech32(string(event.Attributes[0].Value))
-		coins, err := sdk.ParseCoinsNormalized(string(event.Attributes[1].Value))
+		receiver := sdk.MustAccAddressFromBech32(event.Attributes[0].Value)
+		coins, err := sdk.ParseCoinsNormalized(event.Attributes[1].Value)
 		if err != nil {
 			panic(err)
 		}
@@ -362,7 +362,7 @@ func sdkEventToBalanceOperations(status string, event abci.Event) (operations []
 	// rosetta does not have the concept of burning coins, so we need to mock
 	// the burn as a send to an address that cannot be resolved to anything
 	case banktypes.EventTypeCoinBurn:
-		coins, err := sdk.ParseCoinsNormalized(string(event.Attributes[1].Value))
+		coins, err := sdk.ParseCoinsNormalized(event.Attributes[1].Value)
 		if err != nil {
 			panic(err)
 		}

--- a/types/events.go
+++ b/types/events.go
@@ -130,7 +130,7 @@ func ParseTypedEvent(event abci.Event) (proto.Message, error) {
 
 	attrMap := make(map[string]json.RawMessage)
 	for _, attr := range event.Attributes {
-		attrMap[string(attr.Key)] = json.RawMessage(attr.Value)
+		attrMap[attr.Key] = json.RawMessage(attr.Value)
 	}
 
 	attrBytes, err := json.Marshal(attrMap)
@@ -187,17 +187,6 @@ func (a Attribute) String() string {
 // ToKVPair converts an Attribute object into a Tendermint key/value pair.
 func (a Attribute) ToKVPair() abci.EventAttribute {
 	return abci.EventAttribute{Key: a.Key, Value: a.Value}
-}
-
-func toBytes(i interface{}) []byte {
-	switch x := i.(type) {
-	case []uint8:
-		return x
-	case string:
-		return []byte(x)
-	default:
-		panic(i)
-	}
 }
 
 // AppendAttributes adds one or more attributes to an Event.
@@ -295,7 +284,7 @@ func StringifyEvent(e abci.Event) StringEvent {
 	for _, attr := range e.Attributes {
 		res.Attributes = append(
 			res.Attributes,
-			Attribute{Key: string(attr.Key), Value: string(attr.Value)},
+			Attribute{Key: attr.Key, Value: attr.Value},
 		)
 	}
 

--- a/types/events_test.go
+++ b/types/events_test.go
@@ -253,3 +253,73 @@ func (s *eventsTestSuite) TestMarkEventsToIndex() {
 		})
 	}
 }
+
+func (s *eventsTestSuite) TestStringifyEvent() {
+	event := abci.Event{
+		Type: "message",
+		Attributes: []abci.EventAttribute{
+			{Key: "sender", Value: "foo"},
+			{Key: "empty", Value: ""},
+			{Key: "κλειδί", Value: "τιμή 🚀"},
+		},
+	}
+
+	se := sdk.StringifyEvent(event)
+	s.Require().Equal("message", se.Type)
+	s.Require().Equal([]sdk.Attribute{
+		sdk.NewAttribute("sender", "foo"),
+		sdk.NewAttribute("empty", ""),
+		sdk.NewAttribute("κλειδί", "τιμή 🚀"),
+	}, se.Attributes)
+}
+
+func (s *eventsTestSuite) TestParseTypedEvent() {
+	s.Run("parses a hand-built event", func() {
+		event := abci.Event{
+			Type: "cosmos.base.v1beta1.Coin",
+			Attributes: []abci.EventAttribute{
+				{Key: "denom", Value: `"fakedenom"`},
+				{Key: "amount", Value: `"1999999"`},
+			},
+		}
+
+		msg, err := sdk.ParseTypedEvent(event)
+		s.Require().NoError(err)
+		coin, ok := msg.(*sdk.Coin)
+		s.Require().True(ok)
+		s.Require().Equal(sdk.NewCoin("fakedenom", sdk.NewInt(1999999)), *coin)
+	})
+
+	s.Run("duplicate attribute keys: last one wins", func() {
+		event := abci.Event{
+			Type: "cosmos.base.v1beta1.Coin",
+			Attributes: []abci.EventAttribute{
+				{Key: "denom", Value: `"fakedenom"`},
+				{Key: "amount", Value: `"1"`},
+				{Key: "amount", Value: `"2"`},
+			},
+		}
+
+		msg, err := sdk.ParseTypedEvent(event)
+		s.Require().NoError(err)
+		s.Require().Equal("2", msg.(*sdk.Coin).Amount.String())
+	})
+
+	s.Run("unregistered event type", func() {
+		_, err := sdk.ParseTypedEvent(abci.Event{Type: "not.registered.Type"})
+		s.Require().Error(err)
+		s.Require().Contains(err.Error(), "failed to retrieve the message of type")
+	})
+
+	s.Run("invalid attribute value JSON", func() {
+		event := abci.Event{
+			Type: "cosmos.base.v1beta1.Coin",
+			Attributes: []abci.EventAttribute{
+				{Key: "denom", Value: "not-json"},
+			},
+		}
+
+		_, err := sdk.ParseTypedEvent(event)
+		s.Require().Error(err)
+	})
+}


### PR DESCRIPTION
Closes https://github.com/celestiaorg/cosmos-sdk/issues/589

Fixes the three workflows that fail on every Go-touching change to this branch. The Docker-based jobs (Build Simapp Docker, liveness-test) broke because the Dockerfiles build with `golang:1.22.1-alpine` while go.mod now requires go >= 1.23.6, and the localnet targets invoke the standalone `docker-compose` binary that ubuntu-24.04 runners no longer ship. Lint broke because golangci-lint v1.61.0 cannot read Go 1.24 export data now that go.mod declares `toolchain go1.24.4`; bumping it to v1.64.8 also surfaced a handful of unconvert/unused findings left behind by #642, fixed here (behavior-neutral cleanups, now pinned by regression tests in types/events_test.go).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYUn5iYqjJzxx8pKj1MUXp